### PR TITLE
Refactor the CMake code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,101 +1,36 @@
 cmake_minimum_required(VERSION 3.10)
-project(UFEMISM LANGUAGES Fortran)
+project( UPSY_models LANGUAGES Fortran)
 
-set(CMAKE_Fortran_STANDARD 2018)
+set( CMAKE_Fortran_STANDARD 2018)
+
+include( cmake/link_to_dependencies.cmake)
+include( cmake/add_compiler_flags.cmake)
 
 # Collect UPSY/LADDIE/UFEMISM source files
-file(GLOB_RECURSE UPSY_SOURCES    "src/UPSY/*.f90")
-file(GLOB_RECURSE LADDIE_SOURCES  "src/LADDIE/*.f90")
-file(GLOB_RECURSE UFEMISM_SOURCES "src/UFEMISM/*.f90")
+file( GLOB_RECURSE UPSY_sources_raw    "src/UPSY/*.f90")
+file( GLOB_RECURSE LADDIE_sources_raw  "src/LADDIE/*.f90")
+file( GLOB_RECURSE UFEMISM_sources_raw "src/UFEMISM/*.f90")
 
-# Remove all *_configuration.f90 from LADDIE
-foreach(src ${LADDIE_SOURCES})
-    if(src MATCHES ".*/[^/]*_configuration[.]f90$")
-        list(REMOVE_ITEM LADDIE_SOURCES "${src}")
-    endif()
+# Create static library for UPSY
+add_library( UPSY_static_library STATIC ${UPSY_sources_raw})
+link_to_dependencies( UPSY_static_library)
+add_compiler_flags( UPSY_static_library)
+
+# Initialise an empty list of executables
+set( all_programs "")
+
+# UPSY programs
+add_executable( UPSY_unit_test_program src/UPSY/UPSY_unit_test_program.f90)
+list( APPEND all_programs UPSY_unit_test_program)
+
+# UFEMISM programs
+add_executable( UFEMISM_program ${LADDIE_sources_raw} ${UFEMISM_sources_raw} src/UFEMISM/main/UFEMISM_program.f90)
+list( APPEND all_programs UFEMISM_program)
+
+# Link all executables to the UPSY static library and the external dependencies,
+# and set the compiler flags
+foreach(prog IN LISTS all_programs)
+    target_link_libraries(${prog} PRIVATE UPSY_static_library)
+    link_to_dependencies(${prog})
+    add_compiler_flags(${prog})
 endforeach()
-
-# Combine source files
-set(ALL_SOURCES ${UPSY_SOURCES} ${LADDIE_SOURCES} ${UFEMISM_SOURCES})
-
-# Remove all *_program.f90 except for UFEMISM_program.f90
-foreach(src ${ALL_SOURCES})
-    if(src MATCHES ".*/[^/]*_program[.]f90$" AND NOT src MATCHES ".*/UFEMISM_program[.]f90$")
-        list(REMOVE_ITEM ALL_SOURCES "${src}")
-    endif()
-endforeach()
-
-# Create executable with all sources
-add_executable(UFEMISM_program ${ALL_SOURCES})
-
-# Enable preprocessing for all Fortran files
-target_compile_options(UFEMISM_program PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-cpp>)
-
-# Optionally enable assertions
-option(DO_ASSERTIONS "Compile UFEMISM with assertions" ON)
-if(DO_ASSERTIONS)
-    target_compile_definitions(UFEMISM_program PRIVATE DO_ASSERTIONS)
-endif()
-
-# Optionally enable resource tracking
-option(DO_RESOURCE_TRACKING "Compile UFEMISM with resource tracking" ON)
-if(DO_RESOURCE_TRACKING)
-    target_compile_definitions(UFEMISM_program PRIVATE DO_RESOURCE_TRACKING)
-endif()
-
-# Optionally provide extra compiler flags
-set(EXTRA_Fortran_FLAGS "" CACHE STRING "Extra gfortran compiler flags")
-if(EXTRA_Fortran_FLAGS)
-    target_compile_options(UFEMISM_program PRIVATE ${EXTRA_Fortran_FLAGS})
-endif()
-
-# Detect platform
-if(APPLE)
-    set(IS_MACOS TRUE)
-elseif(UNIX)
-    set(IS_LINUX TRUE)
-endif()
-
-# =============
-# == OpenMPI ==
-# =============
-
-# Find MPI package
-find_package(MPI REQUIRED Fortran)
-
-# Add include directories and link libraries
-target_link_libraries(UFEMISM_program PRIVATE MPI::MPI_Fortran)
-
-# ===========
-# == PETSc ==
-# ===========
-
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(PETSC REQUIRED PETSc)
-
-include_directories(${PETSC_INCLUDE_DIRS})
-link_directories(${PETSC_LIBRARY_DIRS})
-add_definitions(${PETSC_CFLAGS_OTHER})
-
-if(IS_LINUX)
-    target_link_libraries(UFEMISM_program PRIVATE ${PETSC_LIBRARIES})
-elseif(IS_MACOS)
-    target_link_libraries(UFEMISM_program PRIVATE ${PETSC_LIBRARY_DIRS}/libpetsc.dylib)
-endif()
-
-# ============
-# == NetCDF ==
-# ============
-
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(NETCDF REQUIRED netcdf-fortran)
-
-include_directories(${NETCDF_INCLUDE_DIRS})
-link_directories(${NETCDF_LIBRARY_DIRS})
-add_definitions(${NETCDF_CFLAGS_OTHER})
-
-if(IS_LINUX)
-    target_link_libraries(UFEMISM_program PRIVATE ${NETCDF_LIBRARIES})
-elseif(IS_MACOS)
-    target_link_libraries(UFEMISM_program PRIVATE ${NETCDF_LIBRARY_DIRS}/libnetcdff.dylib)
-endif()

--- a/cmake/add_compiler_flags.cmake
+++ b/cmake/add_compiler_flags.cmake
@@ -1,0 +1,24 @@
+function(add_compiler_flags target)
+
+  # Enable preprocessing for all Fortran files
+  target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-cpp>)
+
+  # Optionally enable assertions
+  option(DO_ASSERTIONS "Compile with assertions" ON)
+  if(DO_ASSERTIONS)
+      target_compile_definitions(${target} PRIVATE DO_ASSERTIONS)
+  endif()
+
+  # Optionally enable resource tracking
+  option(DO_RESOURCE_TRACKING "Compile with resource tracking" ON)
+  if(DO_RESOURCE_TRACKING)
+      target_compile_definitions(${target} PRIVATE DO_RESOURCE_TRACKING)
+  endif()
+
+  # Optionally provide extra compiler flags
+  set(EXTRA_Fortran_FLAGS "" CACHE STRING "Extra gfortran compiler flags")
+  if(EXTRA_Fortran_FLAGS)
+      target_compile_options(${target} PRIVATE ${EXTRA_Fortran_FLAGS})
+  endif()
+
+endfunction()

--- a/cmake/link_to_dependencies.cmake
+++ b/cmake/link_to_dependencies.cmake
@@ -1,0 +1,54 @@
+function(link_to_dependencies target)
+
+  # Detect platform
+  if(APPLE)
+      set(IS_MACOS TRUE)
+  elseif(UNIX)
+      set(IS_LINUX TRUE)
+  endif()
+
+  # =============
+  # == OpenMPI ==
+  # =============
+
+  # Find MPI package
+  find_package(MPI REQUIRED Fortran)
+
+  # Add include directories and link libraries
+  target_link_libraries(${target} PRIVATE MPI::MPI_Fortran)
+
+  # ===========
+  # == PETSc ==
+  # ===========
+
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(PETSC REQUIRED PETSc)
+
+  include_directories(${PETSC_INCLUDE_DIRS})
+  link_directories(${PETSC_LIBRARY_DIRS})
+  add_definitions(${PETSC_CFLAGS_OTHER})
+
+  if(IS_LINUX)
+      target_link_libraries(${target} PRIVATE ${PETSC_LIBRARIES})
+  elseif(IS_MACOS)
+      target_link_libraries(${target} PRIVATE ${PETSC_LIBRARY_DIRS}/libpetsc.dylib)
+  endif()
+
+  # ============
+  # == NetCDF ==
+  # ============
+
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(NETCDF REQUIRED netcdf-fortran)
+
+  include_directories(${NETCDF_INCLUDE_DIRS})
+  link_directories(${NETCDF_LIBRARY_DIRS})
+  add_definitions(${NETCDF_CFLAGS_OTHER})
+
+  if(IS_LINUX)
+      target_link_libraries(${target} PRIVATE ${NETCDF_LIBRARIES})
+  elseif(IS_MACOS)
+      target_link_libraries(${target} PRIVATE ${NETCDF_LIBRARY_DIRS}/libnetcdff.dylib)
+  endif()
+
+endfunction()


### PR DESCRIPTION
UPSY is now compiled as a static library, to which the executables are linked. This prevents conflicts and speeds up the compilation.

Moved the linking to external dependencies (OpenMPI, PETSc, NetCDF), and the application of compiler flags, to CMake functions to prevent code duplication.

Right now, two executables are compiled: UPSY_unit_test_program, and UFEMISM_program. More executables can be easily defined in CMakeLists.txt.

To do: provide input argumnts to CMakeLists.txt to tell it which executables should be compiled, so that e.g. running ./compile_LADDIE will not compile UFEMISM.