### PR TITLE
Fix cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,21 @@ project( UPSY_models LANGUAGES Fortran)
 
 set( CMAKE_Fortran_STANDARD 2018)
 
+option(BUILD_UPSY "Build the UPSY model" OFF)
+option(BUILD_UFEMISM "Build the UFEMISM model" OFF)
+option(BUILD_LADDIE "Build the LADDIE model" OFF)
+
 include( cmake/link_to_dependencies.cmake)
 include( cmake/add_compiler_flags.cmake)
 
-add_subdirectory(src/UPSY)
-add_subdirectory(src/UFEMISM)
+if(BUILD_UPSY)
+    add_subdirectory(src/UPSY)
+endif(BUILD_UPSY)
+
+if(BUILD_UFEMISM)
+    add_subdirectory(src/UFEMISM)
+endif(BUILD_UFEMISM)
+
+if(BUILD_LADDIE)
+    add_subdirectory(src/LADDIE)
+endif(BUILD_LADDIE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,16 +3,13 @@ project( UPSY_models LANGUAGES Fortran)
 
 set( CMAKE_Fortran_STANDARD 2018)
 
-option(BUILD_UPSY "Build the UPSY model" ON)
 option(BUILD_UFEMISM "Build the UFEMISM model" OFF)
 option(BUILD_LADDIE "Build the LADDIE model" OFF)
 
 include( cmake/link_to_dependencies.cmake)
 include( cmake/add_compiler_flags.cmake)
 
-if(BUILD_UPSY)
-    add_subdirectory(src/UPSY)
-endif(BUILD_UPSY)
+add_subdirectory(src/UPSY)
 
 if(BUILD_UFEMISM)
     add_subdirectory(src/UFEMISM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project( UPSY_models LANGUAGES Fortran)
 
 set( CMAKE_Fortran_STANDARD 2018)
 
-option(BUILD_UPSY "Build the UPSY model" OFF)
+option(BUILD_UPSY "Build the UPSY model" ON)
 option(BUILD_UFEMISM "Build the UFEMISM model" OFF)
 option(BUILD_LADDIE "Build the LADDIE model" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,36 +6,5 @@ set( CMAKE_Fortran_STANDARD 2018)
 include( cmake/link_to_dependencies.cmake)
 include( cmake/add_compiler_flags.cmake)
 
-# Collect UPSY/LADDIE/UFEMISM source files
-file( GLOB_RECURSE UPSY_sources_raw    "src/UPSY/*.f90")
-file( GLOB_RECURSE LADDIE_sources_raw  "src/LADDIE/*.f90")
-list(REMOVE_ITEM LADDIE_sources_raw "${CMAKE_SOURCE_DIR}/src/LADDIE/main/LADDIE_program.f90")
-
-file( GLOB_RECURSE UFEMISM_sources_raw "src/UFEMISM/*.f90")
-list(REMOVE_ITEM UFEMISM_sources_raw "${CMAKE_SOURCE_DIR}/src/UFEMISM/main/UFEMISM_program.f90")
-
-# Create static library for UPSY
-add_library( UPSY_static_library STATIC ${UPSY_sources_raw})
-link_to_dependencies( UPSY_static_library)
-add_compiler_flags( UPSY_static_library)
-
-# Initialise an empty list of executables
-set( all_programs "")
-
-# UPSY programs
-add_executable( UPSY_unit_test_program      src/UPSY/UPSY_unit_test_program.f90)
-add_executable( UPSY_component_test_program src/UPSY/UPSY_component_test_program.f90)
-list( APPEND all_programs UPSY_unit_test_program)
-list( APPEND all_programs UPSY_component_test_program)
-
-# UFEMISM programs
-add_executable( UFEMISM_program ${LADDIE_sources_raw} ${UFEMISM_sources_raw} src/UFEMISM/main/UFEMISM_program.f90)
-list( APPEND all_programs UFEMISM_program)
-
-# Link all executables to the UPSY static library and the external dependencies,
-# and set the compiler flags
-foreach(prog IN LISTS all_programs)
-    target_link_libraries(${prog} PRIVATE UPSY_static_library)
-    link_to_dependencies(${prog})
-    add_compiler_flags(${prog})
-endforeach()
+add_subdirectory(src/UPSY)
+add_subdirectory(src/UFEMISM)

--- a/compile_LADDIE.csh
+++ b/compile_LADDIE.csh
@@ -1,0 +1,149 @@
+#! /bin/csh -f
+
+# Compile all the LADDIE code.
+#
+# Usage: ./compile_LADDIE.csh  [VERSION]  [SELECTION]
+#
+#   [VERSION]: dev, perf
+#
+#     dev : developer's version; extra compiler flags (see Makefile_include, COMPILER_FLAGS_CHECK),
+#           plus run-time assertions (i.e. DO_ASSERTIONS = true) and resource tracking (i.e.
+#           DO_RESOURCE_TRACKING = true). Useful for tracking coding errors, but slow.
+#
+#     perf: performance version; all of the above disabled. Coding errors will much more often
+#           simply result in segmentation faults, but runs much faster.
+#
+#   [SELECTION]: changed, clean
+#
+#     changed: (re)compile only changed modules. Works 99% of the time, fails when you change the
+#              definition of a derived type without recompiling all of the modules thst use that
+#              type. In that case, better to just do a clean compilation.
+#
+#     clean: recompile all modules. Always works, but slower.
+#
+
+# Safety
+if ($#argv != 2) goto usage
+
+echo ""
+
+#  Confirm user's compilation choices
+set version   = $argv[1]
+if ($version == 'dev') then
+  echo "dev: compiling LADDIE, developers' version"
+else if ($version == 'perf') then
+  echo "perf: compiling LADDIE, performance version"
+else
+  goto usage
+endif
+
+set selection = $argv[2]
+if ($selection == 'changed') then
+  echo "changed: (re)compiling changed modules only"
+else if ($selection == 'clean') then
+  echo "clean: recompiling all modules"
+else
+  goto usage
+endif
+
+echo ""
+
+# If no build directory exists, create it
+if (! -d build) mkdir build
+
+# For a "clean" build, remove all build files first
+if ($selection == 'clean') rm -rf build/*
+
+# For a "changed" build, remove only the CMake cache file
+if ($selection == 'changed') rm -f build/CMakeCache.txt
+
+# Use CMake to build LADDIE, with Ninja to determine module dependencies;
+# use different compiler flags for the development/performance build
+cd build
+
+if ($version == 'dev') then
+
+  cmake -G Ninja -DPETSC_DIR=`brew --prefix petsc` \
+    -DBUILD_LADDIE=ON \
+    -DDO_ASSERTIONS=ON \
+    -DDO_RESOURCE_TRACKING=ON \
+    -DEXTRA_Fortran_FLAGS="\
+      -fdiagnostics-color=always;\
+      -Og;\
+      -Wall;\
+      -ffree-line-length-none;\
+      -cpp;\
+      -Werror=implicit-interface;\
+      -fimplicit-none;\
+      -g;\
+      -march=native;\
+      -fcheck=all;\
+      -fbacktrace;\
+      -finit-real=nan;\
+      -finit-integer=-42;\
+      -finit-character=33" ..
+
+else if ($version == 'perf') then
+
+  cmake -G Ninja -DPETSC_DIR=`brew --prefix petsc` \
+    -DBUILD_LADDIE=ON \
+    -DDO_ASSERTIONS=OFF \
+    -DDO_RESOURCE_TRACKING=OFF \
+    -DEXTRA_Fortran_FLAGS="\
+      -fdiagnostics-color=always;\
+      -O3;\
+      -Wall;\
+      -ffree-line-length-none;\
+      -cpp;\
+      -fimplicit-none;\
+      -g;\
+      -march=native" ..
+
+endif
+
+ninja -v
+cd ..
+
+# Copy compiled program
+if ($version == 'dev') then
+
+  rm -f LADDIE_program_dev
+  mv build/src/LADDIE/LADDIE_program LADDIE_program_dev
+  rm -f LADDIE_program
+  cp LADDIE_program_dev LADDIE_program
+
+else if ($version == 'perf') then
+
+  rm -f LADDIE_program_perf
+  mv build/src/LADDIE/LADDIE_program LADDIE_program_perf
+  rm -f LADDIE_program
+  cp LADDIE_program_perf LADDIE_program
+
+endif
+
+exit 0
+
+usage:
+
+echo ""
+echo "Usage: ./compile_LADDIE.csh  [VERSION]  [SELECTION]"
+echo ""
+echo "  [VERSION]: dev, perf"
+echo ""
+echo "    dev : developer's version; extra compiler flags (see Makefile_include, COMPILER_FLAGS_CHECK),"
+echo "          plus run-time assertions (i.e. DO_ASSERTIONS = true) and resource tracking (i.e."
+echo "          DO_RESOURCE_TRACKING = true). Useful for tracking coding errors, but slow."
+echo ""
+echo "    perf: performance version; all of the above disabled. Coding errors will much more often"
+echo "          simply result in segmentation faults, but runs much faster."
+echo ""
+echo "  [SELECTION]: changed, clean"
+echo ""
+echo "    changed: (re)compile only changed modules. Works 99% of the time, fails when you change the"
+echo "             definition of a derived type without recompiling all of the modules thst use that"
+echo "             type. In that case, better to just do a clean compilation."
+echo ""
+echo "    clean: recompile all modules. Always works, but slower."
+echo ""
+
+exit 1

--- a/compile_UFEMISM.csh
+++ b/compile_UFEMISM.csh
@@ -64,6 +64,7 @@ cd build
 if ($version == 'dev') then
 
   cmake -G Ninja -DPETSC_DIR=`brew --prefix petsc` \
+    -DBUILD_UFEMISM=ON \
     -DDO_ASSERTIONS=ON \
     -DDO_RESOURCE_TRACKING=ON \
     -DEXTRA_Fortran_FLAGS="\
@@ -85,6 +86,7 @@ if ($version == 'dev') then
 else if ($version == 'perf') then
 
   cmake -G Ninja -DPETSC_DIR=`brew --prefix petsc` \
+    -DBUILD_UFEMISM=ON \
     -DDO_ASSERTIONS=OFF \
     -DDO_RESOURCE_TRACKING=OFF \
     -DEXTRA_Fortran_FLAGS="\

--- a/compile_UFEMISM.csh
+++ b/compile_UFEMISM.csh
@@ -106,14 +106,14 @@ cd ..
 if ($version == 'dev') then
 
   rm -f UFEMISM_program_dev
-  mv build/UFEMISM_program UFEMISM_program_dev
+  mv build/src/UFEMISM/UFEMISM_program UFEMISM_program_dev
   rm -f UFEMISM_program
   cp UFEMISM_program_dev UFEMISM_program
 
 else if ($version == 'perf') then
 
   rm -f UFEMISM_program_perf
-  mv build/UFEMISM_program UFEMISM_program_perf
+  mv build/src/UFEMISM/UFEMISM_program UFEMISM_program_perf
   rm -f UFEMISM_program
   cp UFEMISM_program_perf UFEMISM_program
 

--- a/compile_UPSY.csh
+++ b/compile_UPSY.csh
@@ -68,6 +68,7 @@ cd build
 if ($version == 'dev') then
 
   cmake -G Ninja -DPETSC_DIR=`brew --prefix petsc` \
+    -DBUILD_UPSY=ON \
     -DDO_ASSERTIONS=ON \
     -DDO_RESOURCE_TRACKING=ON \
     -DEXTRA_Fortran_FLAGS="\
@@ -89,6 +90,7 @@ if ($version == 'dev') then
 else if ($version == 'perf') then
 
   cmake -G Ninja -DPETSC_DIR=`brew --prefix petsc` \
+    -DBUILD_UPSY=ON \
     -DDO_ASSERTIONS=OFF \
     -DDO_RESOURCE_TRACKING=OFF \
     -DEXTRA_Fortran_FLAGS="\

--- a/compile_UPSY.csh
+++ b/compile_UPSY.csh
@@ -48,6 +48,10 @@ endif
 
 echo ""
 
+
+# If no include directory exists, create it
+if (! -d include) mkdir include
+
 # If no build directory exists, create it
 if (! -d build) mkdir build
 
@@ -107,8 +111,8 @@ if ($version == 'dev') then
 
   rm -f UPSY_unit_test_program_dev
   rm -f UPSY_component_test_program_dev
-  mv build/UPSY_unit_test_program UPSY_unit_test_program_dev
-  mv build/UPSY_component_test_program UPSY_component_test_program_dev
+  mv build/src/UPSY/UPSY_unit_test_program UPSY_unit_test_program_dev
+  mv build/src/UPSY/UPSY_component_test_program UPSY_component_test_program_dev
   rm -f UPSY_unit_test_program
   rm -f UPSY_component_test_program
   cp UPSY_unit_test_program_dev UPSY_unit_test_program
@@ -118,8 +122,8 @@ else if ($version == 'perf') then
 
   rm -f UPSY_unit_test_program_perf
   rm -f UPSY_component_test_program_perf
-  mv build/UPSY_unit_test_program UPSY_unit_test_program_perf
-  mv build/UPSY_component_test_program UPSY_component_test_program_perf
+  mv build/src/UPSY/UPSY_unit_test_program UPSY_unit_test_program_perf
+  mv build/src/UPSY/UPSY_component_test_program UPSY_component_test_program_perf
   rm -f UPSY_unit_test_program
   rm -f UPSY_component_test_program
   cp UPSY_unit_test_program_perf UPSY_unit_test_program

--- a/compile_UPSY.csh
+++ b/compile_UPSY.csh
@@ -68,7 +68,6 @@ cd build
 if ($version == 'dev') then
 
   cmake -G Ninja -DPETSC_DIR=`brew --prefix petsc` \
-    -DBUILD_UPSY=ON \
     -DDO_ASSERTIONS=ON \
     -DDO_RESOURCE_TRACKING=ON \
     -DEXTRA_Fortran_FLAGS="\
@@ -90,7 +89,6 @@ if ($version == 'dev') then
 else if ($version == 'perf') then
 
   cmake -G Ninja -DPETSC_DIR=`brew --prefix petsc` \
-    -DBUILD_UPSY=ON \
     -DDO_ASSERTIONS=OFF \
     -DDO_RESOURCE_TRACKING=OFF \
     -DEXTRA_Fortran_FLAGS="\

--- a/src/LADDIE/CMakeLists.txt
+++ b/src/LADDIE/CMakeLists.txt
@@ -1,34 +1,16 @@
 # Collect UPSY/LADDIE/UFEMISM source files
-file( GLOB_RECURSE UPSY_sources_raw    "${CMAKE_CURRENT_SOURCE_DIR}/*.f90")
+file( GLOB_RECURSE UPSY_sources_raw    "${PROJECT_SOURCE_DIR}/src/UPSY/*.f90")
+list(REMOVE_ITEM UPSY_sources_raw "${PROJECT_SOURCE_DIR}/src/UPSY/UPSY_unit_test_program.f90")
+list(REMOVE_ITEM UPSY_sources_raw "${PROJECT_SOURCE_DIR}/src/UPSY/UPSY_component_test_program.f90")
 
-file( GLOB_RECURSE LADDIE_sources_raw  "${PROJECT_SOURCE_DIR}/src/LADDIE/*.f90")
-list(REMOVE_ITEM LADDIE_sources_raw "${PROJECT_SOURCE_DIR}/src/LADDIE/main/LADDIE_program.f90")
+file( GLOB_RECURSE LADDIE_sources_raw  "${CMAKE_CURRENT_SOURCE_DIR}/*.f90")
+list(REMOVE_ITEM LADDIE_sources_raw "${CMAKE_CURRENT_SOURCE_DIR}/main/LADDIE_program.f90")
 
 file( GLOB_RECURSE UFEMISM_sources_raw "${PROJECT_SOURCE_DIR}/src/UFEMISM/*.f90")
 list(REMOVE_ITEM UFEMISM_sources_raw "${PROJECT_SOURCE_DIR}/src/UFEMISM/main/UFEMISM_program.f90")
 
-# Create static library for UPSY
-add_library( UPSY_static_library STATIC ${UPSY_sources_raw})
-link_to_dependencies( UPSY_static_library)
-add_compiler_flags( UPSY_static_library)
+# LADDIE program
+add_executable( LADDIE_program ${UPSY_sources_raw} ${LADDIE_sources_raw} ${UFEMISM_sources_raw} "${CMAKE_CURRENT_SOURCE_DIR}/main/LADDIE_program.f90")
 
-# Initialise an empty list of executables
-set( all_programs "")
-
-# UPSY programs
-add_executable( UPSY_unit_test_program      "${CMAKE_CURRENT_SOURCE_DIR}/UPSY_unit_test_program.f90")
-add_executable( UPSY_component_test_program "${CMAKE_CURRENT_SOURCE_DIR}/UPSY_component_test_program.f90")
-list( APPEND all_programs UPSY_unit_test_program)
-list( APPEND all_programs UPSY_component_test_program)
-
-# UFEMISM programs
-add_executable( UFEMISM_program ${LADDIE_sources_raw} ${UFEMISM_sources_raw} "${PROJECT_SOURCE_DIR}/src/UFEMISM/main/UFEMISM_program.f90")
-list( APPEND all_programs UFEMISM_program)
-
-# Link all executables to the UPSY static library and the external dependencies,
-# and set the compiler flags
-foreach(prog IN LISTS all_programs)
-    target_link_libraries(${prog} PRIVATE UPSY_static_library)
-    link_to_dependencies(${prog})
-    add_compiler_flags(${prog})
-endforeach()
+link_to_dependencies(LADDIE_program)
+add_compiler_flags(LADDIE_program)

--- a/src/LADDIE/CMakeLists.txt
+++ b/src/LADDIE/CMakeLists.txt
@@ -1,8 +1,4 @@
-# Collect UPSY/LADDIE/UFEMISM source files
-file( GLOB_RECURSE UPSY_sources_raw    "${PROJECT_SOURCE_DIR}/src/UPSY/*.f90")
-list(REMOVE_ITEM UPSY_sources_raw "${PROJECT_SOURCE_DIR}/src/UPSY/UPSY_unit_test_program.f90")
-list(REMOVE_ITEM UPSY_sources_raw "${PROJECT_SOURCE_DIR}/src/UPSY/UPSY_component_test_program.f90")
-
+# Collect LADDIE/UFEMISM source files
 file( GLOB_RECURSE LADDIE_sources_raw  "${CMAKE_CURRENT_SOURCE_DIR}/*.f90")
 list(REMOVE_ITEM LADDIE_sources_raw "${CMAKE_CURRENT_SOURCE_DIR}/main/LADDIE_program.f90")
 
@@ -10,7 +6,8 @@ file( GLOB_RECURSE UFEMISM_sources_raw "${PROJECT_SOURCE_DIR}/src/UFEMISM/*.f90"
 list(REMOVE_ITEM UFEMISM_sources_raw "${PROJECT_SOURCE_DIR}/src/UFEMISM/main/UFEMISM_program.f90")
 
 # LADDIE program
-add_executable( LADDIE_program ${UPSY_sources_raw} ${LADDIE_sources_raw} ${UFEMISM_sources_raw} "${CMAKE_CURRENT_SOURCE_DIR}/main/LADDIE_program.f90")
+add_executable( LADDIE_program ${LADDIE_sources_raw} ${UFEMISM_sources_raw} "${CMAKE_CURRENT_SOURCE_DIR}/main/LADDIE_program.f90")
 
+target_link_libraries( LADDIE_program PUBLIC UPSY_static_library)
 link_to_dependencies(LADDIE_program)
 add_compiler_flags(LADDIE_program)

--- a/src/LADDIE/CMakeLists.txt
+++ b/src/LADDIE/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Collect UPSY/LADDIE/UFEMISM source files
+file( GLOB_RECURSE UPSY_sources_raw    "${CMAKE_CURRENT_SOURCE_DIR}/*.f90")
+
+file( GLOB_RECURSE LADDIE_sources_raw  "${PROJECT_SOURCE_DIR}/src/LADDIE/*.f90")
+list(REMOVE_ITEM LADDIE_sources_raw "${PROJECT_SOURCE_DIR}/src/LADDIE/main/LADDIE_program.f90")
+
+file( GLOB_RECURSE UFEMISM_sources_raw "${PROJECT_SOURCE_DIR}/src/UFEMISM/*.f90")
+list(REMOVE_ITEM UFEMISM_sources_raw "${PROJECT_SOURCE_DIR}/src/UFEMISM/main/UFEMISM_program.f90")
+
+# Create static library for UPSY
+add_library( UPSY_static_library STATIC ${UPSY_sources_raw})
+link_to_dependencies( UPSY_static_library)
+add_compiler_flags( UPSY_static_library)
+
+# Initialise an empty list of executables
+set( all_programs "")
+
+# UPSY programs
+add_executable( UPSY_unit_test_program      "${CMAKE_CURRENT_SOURCE_DIR}/UPSY_unit_test_program.f90")
+add_executable( UPSY_component_test_program "${CMAKE_CURRENT_SOURCE_DIR}/UPSY_component_test_program.f90")
+list( APPEND all_programs UPSY_unit_test_program)
+list( APPEND all_programs UPSY_component_test_program)
+
+# UFEMISM programs
+add_executable( UFEMISM_program ${LADDIE_sources_raw} ${UFEMISM_sources_raw} "${PROJECT_SOURCE_DIR}/src/UFEMISM/main/UFEMISM_program.f90")
+list( APPEND all_programs UFEMISM_program)
+
+# Link all executables to the UPSY static library and the external dependencies,
+# and set the compiler flags
+foreach(prog IN LISTS all_programs)
+    target_link_libraries(${prog} PRIVATE UPSY_static_library)
+    link_to_dependencies(${prog})
+    add_compiler_flags(${prog})
+endforeach()

--- a/src/UFEMISM/CMakeLists.txt
+++ b/src/UFEMISM/CMakeLists.txt
@@ -1,8 +1,4 @@
-# Collect UPSY/LADDIE/UFEMISM source files
-file( GLOB_RECURSE UPSY_sources_raw    "${PROJECT_SOURCE_DIR}/src/UPSY/*.f90")
-list(REMOVE_ITEM UPSY_sources_raw "${PROJECT_SOURCE_DIR}/src/UPSY/UPSY_unit_test_program.f90")
-list(REMOVE_ITEM UPSY_sources_raw "${PROJECT_SOURCE_DIR}/src/UPSY/UPSY_component_test_program.f90")
-
+# Collect LADDIE/UFEMISM source files
 file( GLOB_RECURSE LADDIE_sources_raw  "${PROJECT_SOURCE_DIR}/src/LADDIE/*.f90")
 list(REMOVE_ITEM LADDIE_sources_raw "${PROJECT_SOURCE_DIR}/src/LADDIE/main/LADDIE_program.f90")
 
@@ -10,7 +6,8 @@ file( GLOB_RECURSE UFEMISM_sources_raw "${CMAKE_CURRENT_SOURCE_DIR}/*.f90")
 list(REMOVE_ITEM UFEMISM_sources_raw "${CMAKE_CURRENT_SOURCE_DIR}/main/UFEMISM_program.f90")
 
 # UFEMISM program
-add_executable( UFEMISM_program ${UPSY_sources_raw} ${LADDIE_sources_raw} ${UFEMISM_sources_raw} "${CMAKE_CURRENT_SOURCE_DIR}/main/UFEMISM_program.f90")
+add_executable( UFEMISM_program ${LADDIE_sources_raw} ${UFEMISM_sources_raw} "${CMAKE_CURRENT_SOURCE_DIR}/main/UFEMISM_program.f90")
 
+target_link_libraries( UFEMISM_program PUBLIC UPSY_static_library)
 link_to_dependencies(UFEMISM_program)
 add_compiler_flags(UFEMISM_program)

--- a/src/UFEMISM/CMakeLists.txt
+++ b/src/UFEMISM/CMakeLists.txt
@@ -1,21 +1,7 @@
 # Collect UPSY/LADDIE/UFEMISM source files
 file( GLOB_RECURSE UPSY_sources_raw    "${PROJECT_SOURCE_DIR}/src/UPSY/*.f90")
-
-# Create static library for UPSY
-add_library( UPSY_static_library STATIC ${UPSY_sources_raw})
-link_to_dependencies( UPSY_static_library)
-add_compiler_flags( UPSY_static_library)
-
-target_include_directories( UPSY_static_library PUBLIC ${PROJECT_SOURCE_DIR}/include)
-
-# Initialise an empty list of executables
-set( all_programs "")
-
-# UPSY programs
-add_executable( UPSY_unit_test_program      "${CMAKE_CURRENT_SOURCE_DIR}/UPSY_unit_test_program.f90")
-add_executable( UPSY_component_test_program "${CMAKE_CURRENT_SOURCE_DIR}/UPSY_component_test_program.f90")
-list( APPEND all_programs UPSY_unit_test_program)
-list( APPEND all_programs UPSY_component_test_program)
+list(REMOVE_ITEM UPSY_sources_raw "${PROJECT_SOURCE_DIR}/src/UPSY/UPSY_unit_test_program.f90")
+list(REMOVE_ITEM UPSY_sources_raw "${PROJECT_SOURCE_DIR}/src/UPSY/UPSY_component_test_program.f90")
 
 file( GLOB_RECURSE LADDIE_sources_raw  "${PROJECT_SOURCE_DIR}/src/LADDIE/*.f90")
 list(REMOVE_ITEM LADDIE_sources_raw "${PROJECT_SOURCE_DIR}/src/LADDIE/main/LADDIE_program.f90")
@@ -23,13 +9,8 @@ list(REMOVE_ITEM LADDIE_sources_raw "${PROJECT_SOURCE_DIR}/src/LADDIE/main/LADDI
 file( GLOB_RECURSE UFEMISM_sources_raw "${CMAKE_CURRENT_SOURCE_DIR}/*.f90")
 list(REMOVE_ITEM UFEMISM_sources_raw "${CMAKE_CURRENT_SOURCE_DIR}/main/UFEMISM_program.f90")
 
-# UFEMISM programs
+# UFEMISM program
 add_executable( UFEMISM_program ${UPSY_sources_raw} ${LADDIE_sources_raw} ${UFEMISM_sources_raw} "${CMAKE_CURRENT_SOURCE_DIR}/main/UFEMISM_program.f90")
 
-# Link all executables to the UPSY static library and the external dependencies,
-# and set the compiler flags
-foreach(prog IN LISTS all_programs)
-    target_link_libraries(${prog} PUBLIC UPSY_static_library)
-    link_to_dependencies(${prog})
-    add_compiler_flags(${prog})
-endforeach()
+link_to_dependencies(UFEMISM_program)
+add_compiler_flags(UFEMISM_program)

--- a/src/UFEMISM/CMakeLists.txt
+++ b/src/UFEMISM/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Collect UPSY/LADDIE/UFEMISM source files
+file( GLOB_RECURSE UPSY_sources_raw    "${PROJECT_SOURCE_DIR}/src/UPSY/*.f90")
+
+# Create static library for UPSY
+add_library( UPSY_static_library STATIC ${UPSY_sources_raw})
+link_to_dependencies( UPSY_static_library)
+add_compiler_flags( UPSY_static_library)
+
+target_include_directories( UPSY_static_library PUBLIC ${PROJECT_SOURCE_DIR}/include)
+
+# Initialise an empty list of executables
+set( all_programs "")
+
+# UPSY programs
+add_executable( UPSY_unit_test_program      "${CMAKE_CURRENT_SOURCE_DIR}/UPSY_unit_test_program.f90")
+add_executable( UPSY_component_test_program "${CMAKE_CURRENT_SOURCE_DIR}/UPSY_component_test_program.f90")
+list( APPEND all_programs UPSY_unit_test_program)
+list( APPEND all_programs UPSY_component_test_program)
+
+file( GLOB_RECURSE LADDIE_sources_raw  "${PROJECT_SOURCE_DIR}/src/LADDIE/*.f90")
+list(REMOVE_ITEM LADDIE_sources_raw "${PROJECT_SOURCE_DIR}/src/LADDIE/main/LADDIE_program.f90")
+
+file( GLOB_RECURSE UFEMISM_sources_raw "${CMAKE_CURRENT_SOURCE_DIR}/*.f90")
+list(REMOVE_ITEM UFEMISM_sources_raw "${CMAKE_CURRENT_SOURCE_DIR}/main/UFEMISM_program.f90")
+
+# UFEMISM programs
+add_executable( UFEMISM_program ${UPSY_sources_raw} ${LADDIE_sources_raw} ${UFEMISM_sources_raw} "${CMAKE_CURRENT_SOURCE_DIR}/main/UFEMISM_program.f90")
+
+# Link all executables to the UPSY static library and the external dependencies,
+# and set the compiler flags
+foreach(prog IN LISTS all_programs)
+    target_link_libraries(${prog} PUBLIC UPSY_static_library)
+    link_to_dependencies(${prog})
+    add_compiler_flags(${prog})
+endforeach()

--- a/src/UPSY/CMakeLists.txt
+++ b/src/UPSY/CMakeLists.txt
@@ -6,7 +6,9 @@ add_library( UPSY_static_library STATIC ${UPSY_sources_raw})
 link_to_dependencies( UPSY_static_library)
 add_compiler_flags( UPSY_static_library)
 
-target_include_directories( UPSY_static_library PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_include_directories(UPSY_static_library PUBLIC ${PROJECT_SOURCE_DIR}/include ${CMAKE_CURRENT_BINARY_DIR}/mod_files)
+
+set_property(TARGET UPSY_static_library PROPERTY Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod_files)
 
 # Initialise an empty list of executables
 set( all_programs "")

--- a/src/UPSY/CMakeLists.txt
+++ b/src/UPSY/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Collect UPSY/LADDIE/UFEMISM source files
+file( GLOB_RECURSE UPSY_sources_raw    "${CMAKE_CURRENT_SOURCE_DIR}/*.f90")
+
+# Create static library for UPSY
+add_library( UPSY_static_library STATIC ${UPSY_sources_raw})
+link_to_dependencies( UPSY_static_library)
+add_compiler_flags( UPSY_static_library)
+
+target_include_directories( UPSY_static_library PUBLIC ${PROJECT_SOURCE_DIR}/include)
+
+# Initialise an empty list of executables
+set( all_programs "")
+
+# UPSY programs
+add_executable( UPSY_unit_test_program      "${CMAKE_CURRENT_SOURCE_DIR}/UPSY_unit_test_program.f90")
+add_executable( UPSY_component_test_program "${CMAKE_CURRENT_SOURCE_DIR}/UPSY_component_test_program.f90")
+list( APPEND all_programs UPSY_unit_test_program)
+list( APPEND all_programs UPSY_component_test_program)
+
+# Link all executables to the UPSY static library and the external dependencies,
+# and set the compiler flags
+foreach(prog IN LISTS all_programs)
+    target_link_libraries(${prog} PUBLIC UPSY_static_library)
+    link_to_dependencies(${prog})
+    add_compiler_flags(${prog})
+endforeach()


### PR DESCRIPTION
Separated the CMakeLists file into four: one top-level, and one for each model src/<model>. This allows more flexibility into how each model is compiled. 

Also the (for now dummy) LADDIE_program can be compiled.