### PR TITLE
Add create_graph_from_mesh

### DIFF
--- a/src/UPSY/basic/math_utilities/plane_geometry.f90
+++ b/src/UPSY/basic/math_utilities/plane_geometry.f90
@@ -16,7 +16,7 @@ module plane_geometry
     line_from_points, perpendicular_bisector_from_line, line_line_intersection, circumcenter, &
     geometric_center, triangle_area, is_in_triangle, longest_triangle_leg, smallest_triangle_angle, &
     largest_triangle_angle, equiangular_skewness, crop_line_to_domain, encroaches_upon, &
-    interpolate_inside_triangle
+    interpolate_inside_triangle, mirror_p_across_qr
 
   interface interpolate_inside_triangle
     procedure :: interpolate_inside_triangle_dp_2D
@@ -879,5 +879,28 @@ contains
     end if
 
   end subroutine interpolate_inside_triangle_dp_3D
+
+  pure function mirror_p_across_qr( p, q, r) result( s)
+    !< Define s as the mirror of p across the line qr
+
+    ! In/output variables:
+    real(dp), dimension(2), intent(in) :: p, q, r
+    real(dp), dimension(2)             :: s
+
+    ! Local variables:
+    real(dp), dimension(2) :: qr, qrn, qp, proj_qp_on_qr, m
+
+
+    qr = r - q
+    qrn = qr / norm2( qr)
+
+    qp = p - q
+
+    proj_qp_on_qr = qrn * (qp(1)*qrn(1) + qp(2)*qrn(2))
+    m = q + proj_qp_on_qr
+
+    s = m + (m - p)
+
+  end function mirror_p_across_qr
 
 end module plane_geometry

--- a/src/UPSY/io/netcdf_output/netcdf_setup_grid_mesh_in_file.f90
+++ b/src/UPSY/io/netcdf_output/netcdf_setup_grid_mesh_in_file.f90
@@ -9,13 +9,14 @@ module netcdf_setup_grid_mesh_in_file
   use netcdf_basic
   use netcdf_add_field_mesh
   use netcdf, only: NF90_DOUBLE, NF90_INT, NF90_DEF_GRP
+  use graph_types, only: type_graph
 
   implicit none
 
   private
 
   public :: setup_xy_grid_in_netcdf_file, setup_mesh_in_netcdf_file, write_matrix_operators_to_netcdf_file
-  public :: save_xy_grid_as_netcdf, save_mesh_as_netcdf
+  public :: save_xy_grid_as_netcdf, save_mesh_as_netcdf, save_graph_as_netcdf
 
 contains
 
@@ -62,6 +63,28 @@ contains
     call finalise_routine( routine_name)
 
   end subroutine save_mesh_as_netcdf
+
+  subroutine save_graph_as_netcdf( filename, graph)
+
+    ! In/output variables:
+    character(len=*), intent(in   ) :: filename
+    type(type_graph), intent(in   ) :: graph
+
+    ! Local variables:
+    character(len=1024), parameter :: routine_name = 'save_graph_as_netcdf'
+    integer                        :: ncid
+
+    ! Add routine to path
+    call init_routine( routine_name)
+
+    call create_new_netcdf_file_for_writing( filename, ncid)
+    call setup_graph_in_netcdf_file( filename, ncid, graph)
+    call close_netcdf_file( ncid)
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  end subroutine save_graph_as_netcdf
 
   subroutine setup_xy_grid_in_netcdf_file( filename, ncid, grid)
     !< Set up a regular x/y-grid in an existing NetCDF file
@@ -451,6 +474,83 @@ contains
     call finalise_routine( routine_name)
 
   end subroutine setup_mesh_in_netcdf_file
+
+  subroutine setup_graph_in_netcdf_file( filename, ncid, graph)
+    !< Set up a graph in an existing NetCDF file
+
+    ! In/output variables:
+    character(len=*), intent(in   ) :: filename
+    integer,          intent(in   ) :: ncid
+    type(type_graph), intent(in   ) :: graph
+
+    ! Local variables:
+    character(len=1024), parameter :: routine_name = 'setup_graph_in_netcdf_file'
+    integer, dimension(graph%n)    :: is_ghost_int
+
+    integer :: id_dim_vi
+    integer :: id_dim_ci
+    integer :: id_dim_two
+    integer :: id_dim_three
+
+    integer :: id_var_V
+    integer :: id_var_nC
+    integer :: id_var_C
+
+    integer :: id_var_is_ghost
+    integer :: id_var_ghost_nhat
+
+    ! Add routine to path
+    call init_routine( routine_name)
+
+    ! Create graph dimensions
+    call create_dimension( filename, ncid, get_first_option_from_list( field_name_options_dim_nV    ), graph%n     , id_dim_vi   )
+    call create_dimension( filename, ncid, get_first_option_from_list( field_name_options_dim_nC_mem), graph%nC_mem, id_dim_ci   )
+    call create_dimension( filename, ncid, get_first_option_from_list( field_name_options_dim_two   ), 2           , id_dim_two  )
+    call create_dimension( filename, ncid, get_first_option_from_list( field_name_options_dim_three ), 3           , id_dim_three)
+
+    ! == Create mesh variables - node data
+    ! ======================================
+
+    ! V
+    call create_variable( filename, ncid, get_first_option_from_list( field_name_options_V             ), NF90_DOUBLE, (/ id_dim_vi, id_dim_two   /), id_var_V             )
+    call add_attribute_char( filename, ncid, id_var_V, 'long_name'  , 'Node coordinates'         )
+    call add_attribute_char( filename, ncid, id_var_V, 'units'      , 'm'                          )
+    ! nC
+    call create_variable( filename, ncid, get_first_option_from_list( field_name_options_nC            ), NF90_INT   , (/ id_dim_vi               /), id_var_nC            )
+    call add_attribute_char( filename, ncid, id_var_nC, 'long_name'  , 'Number of connections')
+    ! C
+    call create_variable( filename, ncid, get_first_option_from_list( field_name_options_C             ), NF90_INT   , (/ id_dim_vi, id_dim_ci    /), id_var_C             )
+    call add_attribute_char( filename, ncid, id_var_C, 'long_name'  , 'Connections')
+    call add_attribute_char( filename, ncid, id_var_C, 'orientation', 'counter-clockwise'          )
+
+    ! is_ghost
+    call create_variable( filename, ncid, 'is_ghost', NF90_INT, (/ id_dim_vi /), id_var_is_ghost)
+    call add_attribute_char( filename, ncid, id_var_is_ghost, 'long_name', 'Whether a node is a ghost node')
+    call add_attribute_char( filename, ncid, id_var_is_ghost, 'units', '0 = false, 1 = true')
+    ! ghost_nhat
+    call create_variable( filename, ncid, 'ghost_nhat', NF90_DOUBLE, (/ id_dim_vi, id_dim_two /), id_var_ghost_nhat)
+    call add_attribute_char( filename, ncid, id_var_ghost_nhat, 'long_name', 'Ghost-node outward unit normal vector')
+
+    ! == Write graph data to file
+    ! ==========================
+
+    call write_var_primary( filename, ncid, id_var_V    , graph%V    )
+    call write_var_primary( filename, ncid, id_var_nC   , graph%nC   )
+    call write_var_primary( filename, ncid, id_var_C    , graph%C    )
+
+    where (graph%is_ghost)
+      is_ghost_int = 1
+    elsewhere
+      is_ghost_int = 0
+    end where
+
+    call write_var_primary( filename, ncid, id_var_is_ghost, is_ghost_int)
+    call write_var_primary( filename, ncid, id_var_ghost_nhat, graph%ghost_nhat)
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  end subroutine setup_graph_in_netcdf_file
 
   subroutine write_matrix_operators_to_netcdf_file( filename, ncid, mesh)
     !< Write all the matrix operators to the netcdf output file

--- a/src/UPSY/mesh/graph/create_graphs_from_masked_mesh.f90
+++ b/src/UPSY/mesh/graph/create_graphs_from_masked_mesh.f90
@@ -1,0 +1,235 @@
+module create_graphs_from_masked_mesh
+
+  use precisions, only: dp
+  use control_resources_and_error_messaging, only: init_routine, finalise_routine, crash, warning
+  use mesh_types, only: type_mesh
+  use graph_types, only: type_graph
+  use mpi_distributed_memory, only: gather_to_all
+  use mpi_distributed_shared_memory, only: allocate_dist_shared
+  use plane_geometry, only: mirror_p_across_qr
+  use assertions_basic, only: assert
+
+  implicit none
+
+  private
+
+  public :: create_graph_from_masked_mesh_b
+
+  contains
+
+  subroutine create_graph_from_masked_mesh_b( mesh, mask_a, graph)
+
+    ! In/output variables:
+    type(type_mesh),                       intent(in   ) :: mesh
+    logical, dimension(mesh%vi1:mesh%vi2), intent(in   ) :: mask_a
+    type(type_graph),                      intent(  out) :: graph
+
+    ! Local variables:
+    character(len=1024), parameter  :: routine_name = 'create_graph_from_masked_mesh_b'
+    logical, dimension(1:mesh%nV  ) :: mask_a_tot
+    logical, dimension(1:mesh%nTri) :: mask_b_tot
+    integer                         :: n_mask_b
+    logical, dimension(1:mesh%nE  ) :: mask_boundary_c_tot
+    integer                         :: n_boundary_c
+    integer                         :: ni, ti, ng, n, ei, tj, nj, til, tir, vi, vj, vi1, vi2
+    real(dp), dimension(2)          :: p, q, r, s, normal_vector
+
+    ! Add routine to path
+    call init_routine( routine_name)
+
+    ! Calculate b-grid and c-grid masks
+    call gather_to_all( mask_a, mask_a_tot)
+    call calc_masks_b_c( mesh, mask_a_tot, mask_b_tot, n_mask_b, mask_boundary_c_tot, n_boundary_c)
+
+    ! Set graph metadata
+    graph%parent_mesh_name = mesh%name
+    graph%n                = n_mask_b + n_boundary_c
+    graph%nn               = n_mask_b
+    graph%ng               = n_boundary_c
+
+    ! Allocate memory
+    allocate( graph%mi2ni     ( mesh%nTri ), source = 0)
+    allocate( graph%ni2mi     ( graph%n   ), source = 0)
+
+    allocate( graph%V         ( graph%n, 2), source = 0._dp)
+    allocate( graph%nC        ( graph%n   ), source = 0)
+    allocate( graph%C         ( graph%n, 3), source = 0)
+
+    allocate( graph%is_ghost  ( graph%n   ), source = .false.)
+    allocate( graph%ghost_nhat( graph%n, 2), source = 0._dp)
+
+    ! Create triangle-to-node mapping
+    ni = 0
+    do ti = 1, mesh%nTri
+      if (mask_b_tot( ti)) then
+        ni = ni + 1
+        graph%mi2ni( ti) = ni
+        graph%ni2mi( ni) = ti
+      end if
+    end do
+
+    ! Construct reduced graph
+    ng = ni
+    do ti = 1, mesh%nTri
+      if (mask_b_tot( ti)) then
+
+        ni = graph%mi2ni( ti)
+
+        ! Add this masked triangle
+        graph%V ( ni,:) = mesh%TriGC( ti,:)
+        graph%nC( ni  ) = 3
+
+        ! Add its connectivity
+        do n = 1, 3
+
+          ei = mesh%TriE( ti,n)
+          tj = mesh%TriC( ti,n)
+
+          if (mask_b_tot( tj)) then
+            ! This connection points to a masked triangle
+
+            nj = graph%mi2ni( tj)
+            graph%C( ni,n) = nj
+
+          else
+            ! This connection points to a ghost node
+            ng = ng + 1
+            graph%C( ni,n) = ng
+
+            ! Add the ghost node as well
+            graph%is_ghost( ng  ) = .true.
+            graph%ni2mi   ( ng  ) = ei
+            graph%nC      ( ng  ) = 1
+            graph%C       ( ng,1) = ni
+
+            til = mesh%ETri( ei,1)
+            tir = mesh%ETri( ei,2)
+            vi  = mesh%EV( ei,1)
+            vj  = mesh%EV( ei,2)
+
+            ! Define vi1 and vi2 such that the line from vi1 to vi2 has
+            ! the masked mesh interior on its left-hand side
+            if (ti == til) then
+              vi1 = vi
+              vi2 = vj
+            elseif (ti == tir) then
+              vi1 = vj
+              vi2 = vi
+            else
+              call crash('inconsistency in EV/ETri')
+            end if
+
+            ! Calculate coordinates of the ghost node
+            p = mesh%TriGC( ti,:)
+            q = mesh%V( vi1,:)
+            r = mesh%V( vi2,:)
+            s = mirror_p_across_qr( p, q, r)
+            graph%V( ng,:) = s
+
+            ! Calculate unit normal vector
+            normal_vector = graph%V( ng,:) - mesh%TriGC( ti,:)
+            graph%ghost_nhat( ng,:) = normal_vector / norm2( normal_vector)
+
+          end if
+        end do
+
+      end if
+    end do
+
+#if (DO_ASSERTIONS)
+    call assert(test_graph_connectivity_is_self_consistent( graph), 'inconsistent graph connectivity')
+#endif
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  end subroutine create_graph_from_masked_mesh_b
+
+  subroutine calc_masks_b_c( mesh, mask_a_tot, mask_b_tot, n_mask_b, mask_boundary_c_tot, n_boundary_c)
+
+    ! In/output variables:
+    type(type_mesh),               intent(in   ) :: mesh
+    logical, dimension(mesh%nV  ), intent(in   ) :: mask_a_tot
+    logical, dimension(mesh%nTri), intent(  out) :: mask_b_tot
+    integer,                       intent(  out) :: n_mask_b
+    logical, dimension(mesh%nE  ), intent(  out) :: mask_boundary_c_tot
+    integer,                       intent(  out) :: n_boundary_c
+
+    ! Local variables:
+    character(len=1024), parameter  :: routine_name = 'calc_masks_b_c'
+    integer                         :: ti, n_a, n, vi, ei, tj
+
+    ! Add routine to path
+    call init_routine( routine_name)
+
+    ! b mask
+    mask_b_tot = .false.
+    n_mask_b = 0
+    do ti = 1, mesh%nTri
+      n_a = 0
+      do n = 1, 3
+        vi = mesh%Tri( ti,n)
+        if (mask_a_tot( vi)) n_a = n_a + 1
+      end do
+      if (n_a == 3) then
+        mask_b_tot( ti) = .true.
+        n_mask_b = n_mask_b + 1
+      end if
+    end do
+
+    ! c boundary mask
+    mask_boundary_c_tot = .false.
+    n_boundary_c = 0
+    do ei = 1, mesh%nE
+      if (mesh%EBI( ei) == 0) then
+        ti = mesh%ETri( ei,1)
+        tj = mesh%ETri( ei,2)
+        if (xor( mask_b_tot( ti), mask_b_tot( tj))) then
+          mask_boundary_c_tot( ei) = .true.
+          n_boundary_c = n_boundary_c + 1
+        end if
+      end if
+    end do
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  end subroutine calc_masks_b_c
+
+  function test_graph_connectivity_is_self_consistent( graph) result( isso)
+
+    ! In/output variables:
+    type(type_graph), intent(in) :: graph
+    logical                      :: isso
+
+    ! Local variables:
+    character(len=1024), parameter :: routine_name = 'test_graph_connectivity_is_self_consistent'
+    integer                        :: ni, ci, nj, cj, nk
+    logical                        :: found_reverse
+
+    ! Add routine to path
+    call init_routine( routine_name)
+
+    isso = .true.
+
+    do ni = 1, graph%n
+      do ci = 1, graph%nC( ni)
+        nj = graph%C( ni,ci)
+        found_reverse = .false.
+        do cj = 1, graph%nC( nj)
+          nk = graph%C( nj,cj)
+          if (nk == ni) then
+            found_reverse = .true.
+            exit
+          end if
+        end do
+        isso = isso .and. found_reverse
+      end do
+    end do
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  end function test_graph_connectivity_is_self_consistent
+
+end module create_graphs_from_masked_mesh

--- a/src/UPSY/mesh/graph/create_graphs_from_masked_mesh.f90
+++ b/src/UPSY/mesh/graph/create_graphs_from_masked_mesh.f90
@@ -40,17 +40,18 @@ module create_graphs_from_masked_mesh
     graph%n                = count( mask_a_tot)
     graph%nn               = 0
     graph%ng               = 0
+    graph%nC_mem           = maxval( mesh%nC)
 
     ! Allocate memory
-    allocate( graph%mi2ni     ( mesh%nV             ), source = 0)
-    allocate( graph%ni2mi     ( graph%n             ), source = 0)
+    allocate( graph%mi2ni     ( mesh%nV              ), source = 0)
+    allocate( graph%ni2mi     ( graph%n              ), source = 0)
 
-    allocate( graph%V         ( graph%n, 2          ), source = 0._dp)
-    allocate( graph%nC        ( graph%n             ), source = 0)
-    allocate( graph%C         ( graph%n, mesh%nC_mem), source = 0)
+    allocate( graph%V         ( graph%n, 2           ), source = 0._dp)
+    allocate( graph%nC        ( graph%n              ), source = 0)
+    allocate( graph%C         ( graph%n, graph%nC_mem), source = 0)
 
-    allocate( graph%is_ghost  ( graph%n             ), source = .false.)
-    allocate( graph%ghost_nhat( graph%n, 2          ), source = 0._dp)
+    allocate( graph%is_ghost  ( graph%n              ), source = .false.)
+    allocate( graph%ghost_nhat( graph%n, 2           ), source = 0._dp)
 
     ! Create vertex-to-node mapping
     ni = 0
@@ -128,17 +129,18 @@ module create_graphs_from_masked_mesh
     graph%n                = n_mask_b + n_boundary_c
     graph%nn               = n_mask_b
     graph%ng               = n_boundary_c
+    graph%nC_mem           = 3
 
     ! Allocate memory
-    allocate( graph%mi2ni     ( mesh%nTri ), source = 0)
-    allocate( graph%ni2mi     ( graph%n   ), source = 0)
+    allocate( graph%mi2ni     ( mesh%nTri            ), source = 0)
+    allocate( graph%ni2mi     ( graph%n              ), source = 0)
 
-    allocate( graph%V         ( graph%n, 2), source = 0._dp)
-    allocate( graph%nC        ( graph%n   ), source = 0)
-    allocate( graph%C         ( graph%n, 3), source = 0)
+    allocate( graph%V         ( graph%n, 2           ), source = 0._dp)
+    allocate( graph%nC        ( graph%n              ), source = 0)
+    allocate( graph%C         ( graph%n, graph%nC_mem), source = 0)
 
-    allocate( graph%is_ghost  ( graph%n   ), source = .false.)
-    allocate( graph%ghost_nhat( graph%n, 2), source = 0._dp)
+    allocate( graph%is_ghost  ( graph%n              ), source = .false.)
+    allocate( graph%ghost_nhat( graph%n, 2           ), source = 0._dp)
 
     ! Create triangle-to-node mapping
     ni = 0

--- a/src/UPSY/types/graph_types.f90
+++ b/src/UPSY/types/graph_types.f90
@@ -18,6 +18,7 @@ module graph_types
     integer                               :: n                    !< Total number of nodes in the graph
     integer                               :: nn                   !< Number of non-ghost nodes in the graph
     integer                               :: ng                   !< Number of ghost nodes in the graph
+    integer                               :: nC_mem               !< Maximum allowed number of connections per node
 
     ! Mapping between parent mesh and graph
     integer,  dimension(:  ), allocatable :: mi2ni                !<     Graph node (ni) to mesh node (mi) translation table

--- a/src/UPSY/types/graph_types.f90
+++ b/src/UPSY/types/graph_types.f90
@@ -1,0 +1,37 @@
+module graph_types
+
+  use precisions, only: dp
+  use CSR_sparse_matrix_type, only: type_sparse_matrix_CSR_dp
+  use parallel_array_info_type, only: type_par_arr_info
+  use mpi_f08, only: MPI_WIN
+
+  implicit none
+
+  private
+
+  public :: type_graph
+
+  type type_graph
+
+    ! Metadata
+    character(len=1024)                   :: parent_mesh_name     !< Name of this graph's parent mesh
+    integer                               :: n                    !< Total number of nodes in the graph
+    integer                               :: nn                   !< Number of non-ghost nodes in the graph
+    integer                               :: ng                   !< Number of ghost nodes in the graph
+
+    ! Mapping between parent mesh and graph
+    integer,  dimension(:  ), allocatable :: mi2ni                !<     Graph node (ni) to mesh node (mi) translation table
+    integer,  dimension(:  ), allocatable :: ni2mi                !<     Graph node (ni) to mesh node (mi) translation table
+
+    ! Node coordinates and connectivity
+    real(dp), dimension(:,:), allocatable :: V                    !< [m] Node coordinates
+    integer,  dimension(:  ), allocatable :: nC                   !<     Number  of other nodes each node is connected to
+    integer,  dimension(:,:), allocatable :: C                    !<     Indices of other nodes each node is connected to
+
+    ! Ghost nodes
+    logical,  dimension(:  ), allocatable :: is_ghost             !<     Whether or not a node is a ghost node
+    real(dp), dimension(:,:), allocatable :: ghost_nhat           !<     Unit normal vector at each ghost node
+
+  end type type_graph
+
+end module graph_types

--- a/src/UPSY/validation/unit_tests/ut_mesh.f90
+++ b/src/UPSY/validation/unit_tests/ut_mesh.f90
@@ -6,6 +6,7 @@ module ut_mesh
   use ut_mesh_Delaunay, only: test_Delaunay
   use ut_mesh_refinement, only: test_refinement
   use ut_mesh_remapping, only: test_remapping
+  use ut_mesh_graphs, only: test_graphs
 
   implicit none
 
@@ -36,6 +37,7 @@ contains
     call test_Delaunay  ( test_name)
     call test_refinement( test_name)
     call test_remapping ( test_name)
+    call test_graphs    ( test_name)
 
     ! Remove routine from call stack
     call finalise_routine( routine_name)

--- a/src/UPSY/validation/unit_tests/ut_mesh_graphs.f90
+++ b/src/UPSY/validation/unit_tests/ut_mesh_graphs.f90
@@ -1,0 +1,78 @@
+module ut_mesh_graphs
+
+  use tests_main
+  use assertions_basic
+  use ut_basic
+  use precisions, only: dp
+  use control_resources_and_error_messaging, only: init_routine, finalise_routine, crash, warning
+  use mpi_basic, only: par
+  use mesh_types, only: type_mesh
+  use graph_types, only: type_graph
+  use parameters, only: pi
+  use mesh_memory, only: allocate_mesh_primary, crop_mesh_primary
+  use mesh_dummy_meshes, only: initialise_dummy_mesh_5
+  use mesh_refinement_basic, only: refine_mesh_uniform
+  use mesh_secondary, only: calc_all_secondary_mesh_data
+  use create_graphs_from_masked_mesh, only: create_graph_from_masked_mesh_b
+
+  use netcdf_io_main
+
+  implicit none
+
+  private
+
+  public :: test_graphs
+
+contains
+
+  subroutine test_graphs( test_name_parent)
+
+    ! In/output variables:
+    character(len=*), intent(in) :: test_name_parent
+
+    ! Local variables:
+    character(len=1024), parameter     :: routine_name = 'test_graphs'
+    character(len=1024), parameter     :: test_name_local = 'graphs'
+    character(len=1024)                :: test_name
+    real(dp), parameter                :: xmin = -1._dp
+    real(dp), parameter                :: xmax =  1._dp
+    real(dp), parameter                :: ymin = -1._dp
+    real(dp), parameter                :: ymax =  1._dp
+    real(dp)                           :: alpha_min
+    real(dp)                           :: res_max
+    type(type_mesh)                    :: mesh
+    logical, dimension(:), allocatable :: mask_a
+    integer                            :: vi
+    type(type_graph)                   :: graph
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Add test name to list
+    test_name = trim( test_name_parent) // '/' // trim( test_name_local)
+
+    call allocate_mesh_primary( mesh, 'test_mesh', 100, 200)
+    call initialise_dummy_mesh_5( mesh, xmin, xmax, ymin, ymax)
+
+    ! Refine the test mesh
+    alpha_min = 25._dp * pi / 180._dp
+    res_max = pi / 23.2_dp
+    call refine_mesh_uniform( mesh, res_max, alpha_min)
+    call crop_mesh_primary( mesh)
+    call calc_all_secondary_mesh_data( mesh, 0._dp, -90._dp, 71._dp)
+
+    ! Create a graph from the mesh triangles
+    allocate( mask_a( mesh%vi1:mesh%vi2), source = .false.)
+    do vi = mesh%vi1, mesh%vi2
+      if (hypot( mesh%V( vi,1), mesh%V( vi,2)) < mesh%xmax * 0.5_dp) mask_a( vi) = .true.
+    end do
+    call create_graph_from_masked_mesh_b( mesh, mask_a, graph)
+
+    call unit_test( .true., trim( test_name))
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine test_graphs
+
+end module ut_mesh_graphs

--- a/src/UPSY/validation/unit_tests/ut_mesh_graphs.f90
+++ b/src/UPSY/validation/unit_tests/ut_mesh_graphs.f90
@@ -13,7 +13,8 @@ module ut_mesh_graphs
   use mesh_dummy_meshes, only: initialise_dummy_mesh_5
   use mesh_refinement_basic, only: refine_mesh_uniform
   use mesh_secondary, only: calc_all_secondary_mesh_data
-  use create_graphs_from_masked_mesh, only: create_graph_from_masked_mesh_b
+  use create_graphs_from_masked_mesh, only: create_graph_from_masked_mesh_a, create_graph_from_masked_mesh_b, &
+    test_graph_connectivity_is_self_consistent
 
   use netcdf_io_main
 
@@ -43,7 +44,7 @@ contains
     type(type_mesh)                    :: mesh
     logical, dimension(:), allocatable :: mask_a
     integer                            :: vi
-    type(type_graph)                   :: graph
+    type(type_graph)                   :: graph_a, graph_b
 
     ! Add routine to call stack
     call init_routine( routine_name)
@@ -61,14 +62,18 @@ contains
     call crop_mesh_primary( mesh)
     call calc_all_secondary_mesh_data( mesh, 0._dp, -90._dp, 71._dp)
 
-    ! Create a graph from the mesh triangles
+    ! Define a masked set of vertices
     allocate( mask_a( mesh%vi1:mesh%vi2), source = .false.)
     do vi = mesh%vi1, mesh%vi2
       if (hypot( mesh%V( vi,1), mesh%V( vi,2)) < mesh%xmax * 0.5_dp) mask_a( vi) = .true.
     end do
-    call create_graph_from_masked_mesh_b( mesh, mask_a, graph)
 
-    call unit_test( .true., trim( test_name))
+    ! Create graphs from the masked vertices and triangles
+    call create_graph_from_masked_mesh_a( mesh, mask_a, graph_a)
+    call create_graph_from_masked_mesh_b( mesh, mask_a, graph_b)
+
+    call unit_test( test_graph_connectivity_is_self_consistent( graph_a), trim( test_name) // '/a')
+    call unit_test( test_graph_connectivity_is_self_consistent( graph_b), trim( test_name) // '/b')
 
     ! Remove routine from call stack
     call finalise_routine( routine_name)

--- a/tools/matlab/add_graph_to_plot.m
+++ b/tools/matlab/add_graph_to_plot.m
@@ -1,0 +1,49 @@
+function H = add_graph_to_plot( ax, graph, varargin)
+
+nn = sum( graph.nC)*3;
+xx = zeros( nn,1);
+yy = zeros( nn,1);
+
+n = 0;
+for ni = 1: graph.n
+  for ci = 1: graph.nC( ni)
+    nj = graph.C( ni,ci);
+    xx( n+1:n+3) = [graph.V( ni,1); graph.V( nj,1); NaN];
+    yy( n+1:n+3) = [graph.V( ni,2); graph.V( nj,2); NaN];
+    n = n+3;
+  end
+end
+
+linewidth       = 1;
+linestyle       = '-';
+color           = 'k';
+marker          = 'none';
+markersize      = 8;
+markerfacecolor = 'none';
+markeredgecolor = 'k';
+
+for vi = 1: 2: length( varargin)
+  switch varargin{vi}
+    case 'linewidth'
+      linewidth = varargin{vi+1};
+    case 'linestyle'
+      linestyle = varargin{vi+1};
+    case 'color'
+      color = varargin{vi+1};
+    case 'marker'
+      marker = varargin{vi+1};
+    case 'markersize'
+      markersize = varargin{vi+1};
+    case 'markerfacecolor'
+      markerfacecolor = varargin{vi+1};
+    case 'markeredgecolor'
+      markeredgecolor = varargin{vi+1};
+  end
+end
+
+H = line('parent',ax,'xdata',xx,'ydata',yy,...
+  'linewidth',linewidth,'linestyle',linestyle,'color',color,...
+  'marker',marker','markersize',markersize,...
+  'markerfacecolor',markerfacecolor,'markeredgecolor',markeredgecolor);
+
+end

--- a/tools/matlab/read_graph_from_file.m
+++ b/tools/matlab/read_graph_from_file.m
@@ -1,0 +1,14 @@
+function graph = read_graph_from_file( filename)
+
+graph.V              = ncread( filename,'V');
+graph.nC             = ncread( filename,'nC');
+graph.C              = ncread( filename,'C');
+
+graph.is_ghost       = ncread( filename,'is_ghost') == 1;
+graph.ghost_nhat     = ncread( filename,'ghost_nhat');
+
+graph.n              = size( graph.V,1);
+graph.ng             = sum( graph.is_ghost);
+graph.nn             = graph.n - graph.ng;
+
+end


### PR DESCRIPTION
Add code for creating a graph (i.e. just node coordinates and connectivity) from mesh vertices or triangles. Needed for the upcoming calving front boundary conditions. Includes unit tests.