### PR TITLE
Enforce contiguous process domains on graph

### DIFF
--- a/src/UPSY/mesh/graph/create_graphs_from_masked_mesh.f90
+++ b/src/UPSY/mesh/graph/create_graphs_from_masked_mesh.f90
@@ -16,7 +16,7 @@ module create_graphs_from_masked_mesh
   public :: create_graph_from_masked_mesh_a, create_graph_from_masked_mesh_b, &
     test_graph_connectivity_is_self_consistent
 
-  contains
+contains
 
   subroutine create_graph_from_masked_mesh_a( mesh, mask_a, graph)
 

--- a/src/UPSY/mesh/graph/graph_contiguous_domains.f90
+++ b/src/UPSY/mesh/graph/graph_contiguous_domains.f90
@@ -1,0 +1,93 @@
+module graph_contiguous_domains
+
+  use precisions, only: dp
+  use control_resources_and_error_messaging, only: init_routine, finalise_routine
+  use graph_types, only: type_graph
+  use sorting, only: quick_n_dirty_sort
+
+  implicit none
+
+  private
+
+  public :: enforce_contiguous_process_domains_graph
+
+contains
+
+  !> Shuffle nodes so that the nodes owned by each process form
+  !> a contiguous domain with short borders, to minimise the data volumes for halo exchanges.
+  subroutine enforce_contiguous_process_domains_graph( graph)
+
+    ! In/output variables:
+    type(type_graph), intent(inout) :: graph
+
+    ! Local variables:
+    character(len=256), parameter              :: routine_name = 'enforce_contiguous_process_domains_graph'
+    real(dp), dimension(graph%n)               :: xx
+    integer,  dimension(graph%n)               :: ni_new2ni_old, ni_old2ni_new
+    integer                                    :: ni_old, ni_new, ci, nj_old, nj_new
+    real(dp), dimension(graph%n,2)             :: V_old
+    integer,  dimension(graph%n)               :: nC_old
+    integer,  dimension(graph%n, graph%nC_mem) :: C_old
+    logical,  dimension(graph%n)               :: is_ghost_old
+    real(dp), dimension(graph%n,2)             :: ghost_nhat_old
+
+    ! Add routine to path
+    call init_routine( routine_name)
+
+    ! Sort nodes by x-coordinate
+    xx = graph%V( :,1)
+    call quick_n_dirty_sort( xx, ni_new2ni_old)
+
+    ! Calculate translation table in the opposite direction
+    do ni_new = 1, graph%n
+      ni_old = ni_new2ni_old( ni_new)
+      ni_old2ni_new( ni_old) = ni_new
+    end do
+
+    ! Shuffle node data: V, nC, C
+    ! ===========================
+
+    V_old          = graph%V
+    nC_old         = graph%nC
+    C_old          = graph%C
+    is_ghost_old   = graph%is_ghost
+    ghost_nhat_old = graph%ghost_nhat
+
+    graph%V          = 0._dp
+    graph%nC         = 0
+    graph%C          = 0
+    graph%is_ghost   = .false.
+    graph%ghost_nhat = 0._dp
+
+    do ni_new = 1, graph%n
+
+      ! This new node corresponds to this old node
+      ni_old = ni_new2ni_old( ni_new)
+
+      ! V
+      graph%V( ni_new,:) = V_old( ni_old,:)
+
+      ! nC
+      graph%nC( ni_new) = nC_old( ni_old)
+
+      ! C
+      do ci = 1, graph%nC( ni_new)
+        nj_old = C_old( ni_old, ci)
+        nj_new = ni_old2ni_new( nj_old)
+        graph%C( ni_new,ci) = nj_new
+      end do
+
+      ! is_ghost
+      graph%is_ghost( ni_new) = is_ghost_old( ni_old)
+
+      ! ghost_nhat
+      graph%ghost_nhat( ni_new,:) = ghost_nhat_old( ni_old,:)
+
+    end do
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  end subroutine enforce_contiguous_process_domains_graph
+
+end module graph_contiguous_domains

--- a/src/UPSY/validation/unit_tests/ut_mesh_graphs.f90
+++ b/src/UPSY/validation/unit_tests/ut_mesh_graphs.f90
@@ -15,6 +15,7 @@ module ut_mesh_graphs
   use mesh_secondary, only: calc_all_secondary_mesh_data
   use create_graphs_from_masked_mesh, only: create_graph_from_masked_mesh_a, create_graph_from_masked_mesh_b, &
     test_graph_connectivity_is_self_consistent
+  use graph_contiguous_domains, only: enforce_contiguous_process_domains_graph
 
   use netcdf_io_main
 
@@ -32,19 +33,16 @@ contains
     character(len=*), intent(in) :: test_name_parent
 
     ! Local variables:
-    character(len=1024), parameter     :: routine_name = 'test_graphs'
-    character(len=1024), parameter     :: test_name_local = 'graphs'
-    character(len=1024)                :: test_name
-    real(dp), parameter                :: xmin = -1._dp
-    real(dp), parameter                :: xmax =  1._dp
-    real(dp), parameter                :: ymin = -1._dp
-    real(dp), parameter                :: ymax =  1._dp
-    real(dp)                           :: alpha_min
-    real(dp)                           :: res_max
-    type(type_mesh)                    :: mesh
-    logical, dimension(:), allocatable :: mask_a
-    integer                            :: vi
-    type(type_graph)                   :: graph_a, graph_b
+    character(len=1024), parameter :: routine_name = 'test_graphs'
+    character(len=1024), parameter :: test_name_local = 'graphs'
+    character(len=1024)            :: test_name
+    real(dp), parameter            :: xmin = -1._dp
+    real(dp), parameter            :: xmax =  1._dp
+    real(dp), parameter            :: ymin = -1._dp
+    real(dp), parameter            :: ymax =  1._dp
+    real(dp)                       :: alpha_min
+    real(dp)                       :: res_max
+    type(type_mesh)                :: mesh
 
     ! Add routine to call stack
     call init_routine( routine_name)
@@ -62,6 +60,34 @@ contains
     call crop_mesh_primary( mesh)
     call calc_all_secondary_mesh_data( mesh, 0._dp, -90._dp, 71._dp)
 
+    call test_create_graph_from_masked_mesh( test_name, mesh)
+    call test_enforce_contiguous_process_domains_graph( test_name, mesh)
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine test_graphs
+
+  subroutine test_create_graph_from_masked_mesh( test_name_parent, mesh)
+
+    ! In/output variables:
+    character(len=*), intent(in) :: test_name_parent
+    type(type_mesh),  intent(in) :: mesh
+
+    ! Local variables:
+    character(len=1024), parameter     :: routine_name = 'test_create_graph_from_masked_mesh'
+    character(len=1024), parameter     :: test_name_local = 'create_graph_from_masked_mesh'
+    character(len=1024)                :: test_name
+    logical, dimension(:), allocatable :: mask_a
+    integer                            :: vi
+    type(type_graph)                   :: graph_a, graph_b
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Add test name to list
+    test_name = trim( test_name_parent) // '/' // trim( test_name_local)
+
     ! Define a masked set of vertices
     allocate( mask_a( mesh%vi1:mesh%vi2), source = .false.)
     do vi = mesh%vi1, mesh%vi2
@@ -78,6 +104,62 @@ contains
     ! Remove routine from call stack
     call finalise_routine( routine_name)
 
-  end subroutine test_graphs
+  end subroutine test_create_graph_from_masked_mesh
+
+  subroutine test_enforce_contiguous_process_domains_graph( test_name_parent, mesh)
+
+    ! In/output variables:
+    character(len=*), intent(in) :: test_name_parent
+    type(type_mesh),  intent(in) :: mesh
+
+    ! Local variables:
+    character(len=1024), parameter     :: routine_name = 'test_enforce_contiguous_process_domains_graph'
+    character(len=1024), parameter     :: test_name_local = 'enforce_contiguous_process_domains_graph'
+    character(len=1024)                :: test_name
+    logical, dimension(:), allocatable :: mask_a
+    integer                            :: vi
+    type(type_graph)                   :: graph_a, graph_b
+    integer                            :: ni
+    logical                            :: is_sorted
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Add test name to list
+    test_name = trim( test_name_parent) // '/' // trim( test_name_local)
+
+    ! Define a masked set of vertices
+    allocate( mask_a( mesh%vi1:mesh%vi2), source = .false.)
+    do vi = mesh%vi1, mesh%vi2
+      if (hypot( mesh%V( vi,1), mesh%V( vi,2)) < mesh%xmax * 0.5_dp) mask_a( vi) = .true.
+    end do
+
+    ! Create graphs from the masked vertices and triangles
+    call create_graph_from_masked_mesh_a( mesh, mask_a, graph_a)
+    call create_graph_from_masked_mesh_b( mesh, mask_a, graph_b)
+
+    ! Sort the nodes in the graph by x-coordinate, thereby enforcing contiguous process domains
+    call enforce_contiguous_process_domains_graph( graph_a)
+    call enforce_contiguous_process_domains_graph( graph_b)
+
+    call unit_test( test_graph_connectivity_is_self_consistent( graph_a), trim( test_name) // '/a/self_consistent')
+    call unit_test( test_graph_connectivity_is_self_consistent( graph_b), trim( test_name) // '/b/self_consistent')
+
+    is_sorted = .true.
+    do ni = 2, graph_a%n
+      is_sorted = is_sorted .and. graph_a%V( ni,1) >= graph_a%V( ni-1,1)
+    end do
+    call unit_test( is_sorted, trim( test_name) // '/a/is_sorted')
+
+    is_sorted = .true.
+    do ni = 2, graph_b%n
+      is_sorted = is_sorted .and. graph_b%V( ni,1) >= graph_b%V( ni-1,1)
+    end do
+    call unit_test( is_sorted, trim( test_name) // '/b/is_sorted')
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine test_enforce_contiguous_process_domains_graph
 
 end module ut_mesh_graphs

--- a/tools/matlab/add_graph_to_plot.m
+++ b/tools/matlab/add_graph_to_plot.m
@@ -1,49 +1,61 @@
 function H = add_graph_to_plot( ax, graph, varargin)
 
-nn = sum( graph.nC)*3;
-xx = zeros( nn,1);
-yy = zeros( nn,1);
+% Regular nodes
+nn = sum( graph.nC( 1: graph.nn))*3;
+xx = NaN( nn,1);
+yy = NaN( nn,1);
 
 n = 0;
-for ni = 1: graph.n
+for ni = 1: graph.nn
   for ci = 1: graph.nC( ni)
     nj = graph.C( ni,ci);
-    xx( n+1:n+3) = [graph.V( ni,1); graph.V( nj,1); NaN];
-    yy( n+1:n+3) = [graph.V( ni,2); graph.V( nj,2); NaN];
+    if (~graph.is_ghost( nj))
+      xx( n+1:n+3) = [graph.V( ni,1); graph.V( nj,1); NaN];
+      yy( n+1:n+3) = [graph.V( ni,2); graph.V( nj,2); NaN];
+      n = n+3;
+    end
+  end
+end
+
+% Ghost nodes
+nn = sum( graph.nC( graph.nn+1 : graph.n))*3;
+xxg = NaN( nn,1);
+yyg = NaN( nn,1);
+
+n = 0;
+for ni = graph.nn+1 : graph.n
+  for ci = 1: graph.nC( ni)
+    nj = graph.C( ni,ci);
+    xxg( n+1:n+3) = [graph.V( ni,1); graph.V( nj,1); NaN];
+    yyg( n+1:n+3) = [graph.V( ni,2); graph.V( nj,2); NaN];
     n = n+3;
   end
 end
 
+%% Plot
+
 linewidth       = 1;
-linestyle       = '-';
 color           = 'k';
-marker          = 'none';
-markersize      = 8;
-markerfacecolor = 'none';
-markeredgecolor = 'k';
+markersize      = 5;
 
 for vi = 1: 2: length( varargin)
   switch varargin{vi}
     case 'linewidth'
       linewidth = varargin{vi+1};
-    case 'linestyle'
-      linestyle = varargin{vi+1};
     case 'color'
       color = varargin{vi+1};
-    case 'marker'
-      marker = varargin{vi+1};
     case 'markersize'
       markersize = varargin{vi+1};
-    case 'markerfacecolor'
-      markerfacecolor = varargin{vi+1};
-    case 'markeredgecolor'
-      markeredgecolor = varargin{vi+1};
   end
 end
 
-H = line('parent',ax,'xdata',xx,'ydata',yy,...
-  'linewidth',linewidth,'linestyle',linestyle,'color',color,...
-  'marker',marker','markersize',markersize,...
-  'markerfacecolor',markerfacecolor,'markeredgecolor',markeredgecolor);
+H(1) = line('parent',ax,'xdata',xx,'ydata',yy,...
+  'linewidth',linewidth,'linestyle','-','color',color,...
+  'marker','o','markersize',markersize,...
+  'markerfacecolor',color,'markeredgecolor',color);
+H(2) = line('parent',ax,'xdata',xxg,'ydata',yyg,...
+  'linewidth',linewidth,'linestyle','--','color',color,...
+  'marker','o','markersize',markersize,...
+  'markerfacecolor','none','markeredgecolor',color);
 
 end


### PR DESCRIPTION
As with the mesh, this is achieved by sorting nodes by their x-coordinate.