### PR TITLE
Laddie bias

### DIFF
--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:02</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.5724</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.5723</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.5722</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.572</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:03</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>9.2535e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.0404e-05</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.00011207</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.00014998</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:04</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.22294</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.42479</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.74691</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.087</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:04</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.9531</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.9531</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.953</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.953</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:05</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.3542e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0015207</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0030343</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0045392</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:06</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.21985</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>4.4874</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>8.9504</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>13.4051</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:06</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2308</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.2308</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.2307</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.2307</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:07</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.2019e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.002279</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0045468</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0068034</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:08</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.22041</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>4.4642</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>8.9057</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>13.339</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:09</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.5434</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.5434</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.5433</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.5432</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:09</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.1111e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0054681</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.010914</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.016339</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:10</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.18925</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.4783</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>6.9309</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>10.379</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:11</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>5.471</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.471</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.4709</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.4709</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:12</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3457e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0049488</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0098842</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.014806</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:12</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.2381</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.015</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9948</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.974</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:13</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.8226</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.8226</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.8225</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.8225</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:14</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3079e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0020247</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.004044</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.006058</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:15</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23949</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.9606</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.8862</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.8113</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:16</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.7709</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.7709</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.7708</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.7707</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:17</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3247e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0042416</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0084718</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.012691</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:18</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.2385</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.9866</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9378</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.8886</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:18</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.8497</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.8497</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.8496</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.8495</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:19</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3289e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0046293</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0092462</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.013851</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:20</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23831</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.0014</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9676</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.9332</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:21</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>7.3298</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>7.3298</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>7.3298</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>7.3297</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:22</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3373e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.00482</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.009627</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.014421</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:22</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23823</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.0105</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9858</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.9605</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:23</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.0983</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.0983</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.0983</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.0983</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:24</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0090051</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.017991</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.026958</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:24</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.31135</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.6359</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.2199</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>7.8075</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:25</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3326</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.3326</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.3326</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.3326</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:26</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0021267</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0042505</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0063716</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:27</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.42769</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.2308</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>4.3518</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>6.4847</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:27</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.0509</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.0509</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.0509</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.0509</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:28</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0072914</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.014574</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.021848</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:29</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.57588</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.0203</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.8555</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.716</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:30</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.3631</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.363</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.3629</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.3628</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:30</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.6269e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0054374</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.010846</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.016226</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic_2c958743864b777cb058bc18a2d2aec93fe042eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>13-Aug-2025 17:43:31</date_and_time>
+    <git_hash_string>2c958743864b777cb058bc18a2d2aec93fe042eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.1601</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>4.1438</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>8.2687</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>12.3847</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_flowline_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_flowline_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_dHdt_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>13-Aug-2025 18:22:48</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.1507</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>3.4158</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.052501</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>13331</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>13331</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>844839</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_local_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_local_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_dHdt_local</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>13-Aug-2025 18:22:50</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.41802</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>8.4522</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.21455</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>21343</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>21343</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1395293</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_u_flowline_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_u_flowline_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_u_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>13-Aug-2025 18:22:51</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.46164</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>18.5146</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.08951</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>21329</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>21329</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1360630</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_dHdt_invfric_invBMB_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_dHdt_invfric_invBMB_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_dHdt_invfric_invBMB</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>13-Aug-2025 18:22:52</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.47488</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target [m]</definition>
+        <value>30.2662</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.11158</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_melt_rate</name>
+        <definition>95% of melt rates are within this range of its target [m/yr]</definition>
+        <value>3.8258</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>15045</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>15045</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1123754</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_flowline_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_flowline_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_dHdt_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>13-Aug-2025 17:50:45</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.039892</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>7.96</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.029714</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>7261</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>7305</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>188787</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_local_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_local_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_dHdt_local</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>13-Aug-2025 17:50:48</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.17785</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>44.9116</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.14388</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>12752</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>13276</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>235318</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_u_flowline_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_u_flowline_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_u_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>13-Aug-2025 17:50:49</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.091395</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>32.7461</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.068935</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>12342</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>12451</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>236629</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_10km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_10km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_10km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>13-Aug-2025 17:19:18</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>18.0239</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>1202</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_20km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_20km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_20km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>13-Aug-2025 17:19:18</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>22.7642</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>755</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_40km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_40km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_40km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>13-Aug-2025 17:19:16</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>34.8512</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>606</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_5km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_5km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_5km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>13-Aug-2025 17:19:19</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>14.6275</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>2571</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_10km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_10km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_10km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>13-Aug-2025 17:19:21</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>37.5749</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27490</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_20km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_20km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_20km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>13-Aug-2025 17:19:20</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>50.4243</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27480</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_40km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_40km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_40km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>13-Aug-2025 17:19:20</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>45.7239</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27378</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_5km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_5km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_5km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>13-Aug-2025 17:19:22</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>28.4531</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27494</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIP_mod_MISMIP_mod_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIP_mod_MISMIP_mod_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>MISMIP_mod</name>
+    <category>integrated_tests/idealised/MISMIP_mod</category>
+    <date_and_time>13-Aug-2025 18:24:03</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>GL_hyst_east</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>5780.5121</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_northeast</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>696.7631</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_north</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>7406.551</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_northwest</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>2896.4602</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_west</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>5732.0763</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_southwest</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>429.7926</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_south</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>4068.474</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_southeast</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>598.8942</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>5939</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>5960</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>544735</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISMIPplus_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISMIPplus_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>MISMIPplus</name>
+    <category>integrated_tests/idealised/MISMIPplus</category>
+    <date_and_time>13-Aug-2025 17:38:01</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>err_x_GL_init</name>
+        <definition>abs( x_GL(1) - 450e3)</definition>
+        <value>716.0994</value>
+    </cost_functions>
+    <cost_functions>
+        <name>err_x_GL_final_lo</name>
+        <definition>abs( min( 0, x_GL( end) - 350e3))</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>err_x_GL_final_hi</name>
+        <definition>abs( max( 0, x_GL( end) - 420e3))</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>var_x_GL</name>
+        <definition>max( abs( x_GL_smooth - x_GL))</definition>
+        <value>927.4266</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>6596</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>6596</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>608865</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISOMIP_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISOMIP_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<single_run>
+    <name>MISOMIP</name>
+    <category>integrated_tests/idealised/MISMIPplus</category>
+    <date_and_time>2025-08-13 17:38:05</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>err_x_GL_final_lo</name>
+        <definition>abs( min( 0, x_GL[-1] - 430e3))</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>err_x_GL_final_hi</name>
+        <definition>abs( max( 0, x_GL[-1] - 450e3))</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_SSA_icestream_SSA_icestream_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_SSA_icestream_SSA_icestream_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>SSA_icestream</name>
+    <category>integrated_tests/idealised/SSA_icestream</category>
+    <date_and_time>13-Aug-2025 19:11:38</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>RMSE_32km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>400.4197</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_16km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>303.7011</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_8km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>151.9449</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_4km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>81.3852</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>1</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>727</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>782314</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_realistic_Antarctica_initialisation_Ant_init_20kyr_invBMB_invfric_40km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_realistic_Antarctica_initialisation_Ant_init_20kyr_invBMB_invfric_40km_6991b5c06dfdf85ccafcd4e1df99eded33914497.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Ant_init_20kyr_invBMB_invfric_40km</name>
+    <category>integrated_tests/realistic/Antarctica/initialisation</category>
+    <date_and_time>13-Aug-2025 20:01:26</date_and_time>
+    <git_hash_string>6991b5c06dfdf85ccafcd4e1df99eded33914497</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi( :,1)).^2 ))</definition>
+        <value>77.987</value>
+    </cost_functions>
+    <cost_functions>
+        <name>peak_volume_difference</name>
+        <definition>max( abs( ice_volume - ice_volume(1)))</definition>
+        <value>0.90421</value>
+    </cost_functions>
+    <cost_functions>
+        <name>final_volume_difference</name>
+        <definition>ice_volume( end) - ice_volume(1)</definition>
+        <value>0.20423</value>
+    </cost_functions>
+    <cost_functions>
+        <name>ice_volume_var</name>
+        <definition>max( ice_volume( last 5000 yr)) - min( ice_volume( last 5000 yr))</definition>
+        <value>0.017858</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>28112</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>32354</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>3659808</value>
+    </cost_functions>
+</single_run>

--- a/src/LADDIE/laddie_tracers.f90
+++ b/src/LADDIE/laddie_tracers.f90
@@ -60,6 +60,7 @@ CONTAINS
         ! Time-derivative heat equation
         dHTdt = -laddie%divQT( vi) &
                + laddie%melt( vi) * laddie%T_base( vi) &
+               - laddie%gamma_T( vi) * (npx_ref%T( vi) - laddie%T_base( vi)) &
                + MAX(0.0_dp,laddie%entr( vi)) * laddie%T_amb( vi) &
                + laddie%entr_dmin( vi) * laddie%T_amb( vi) &
                - laddie%detr( vi) * npx_ref%T( vi) &

--- a/src/UPSY/basic/model_configuration.f90
+++ b/src/UPSY/basic/model_configuration.f90
@@ -698,10 +698,13 @@ MODULE model_configuration
     CHARACTER(LEN=256)  :: choice_ocean_model_ANT_config                = 'none'
 
     ! Choice of idealised ocean model
-    CHARACTER(LEN=256)  :: choice_ocean_model_idealised_config          = ''                               ! Choice of idealised ocean forcing: 'ISOMIP', 'TANH'
+    CHARACTER(LEN=256)  :: choice_ocean_model_idealised_config          = ''                               ! Choice of idealised ocean forcing: 'ISOMIP', 'TANH', 'LINEAR'
     CHARACTER(LEN=256)  :: choice_ocean_isomip_scenario_config          = ''                               ! Scenario when using 'ISOMIP' forcing: 'WARM' or 'COLD'
     REAL(dp)            :: ocean_tanh_deep_temperature_config           = 1.0_dp                           ! [degC] Deep ocean temperature when using 'TANH' forcing
     REAL(dp)            :: ocean_tanh_thermocline_depth_config          = 100.0_dp                         ! [m]    Depth of thermocline when using 'TANH' forcing
+    real(dp)            :: ocean_linear_deep_temperature_config         = -2.3_dp                          ! [degC] Deep ocean temperature when using 'LINEAR' forcing
+    real(dp)            :: ocean_linear_deep_salinity_config            = 34.8_dp                          ! [psu] Deep ocean salinity when using 'LINEAR' forcing
+    real(dp)            :: ocean_linear_reference_depth_config          = 2000.0_dp                        ! [m] Depth where deep values are prescribed
 
     ! Choice of realistic ocean model
     CHARACTER(LEN=256)  :: choice_ocean_model_realistic_config          = ''
@@ -1824,6 +1827,9 @@ MODULE model_configuration
     CHARACTER(LEN=256)  :: choice_ocean_isomip_scenario
     REAL(dp)            :: ocean_tanh_deep_temperature
     REAL(dp)            :: ocean_tanh_thermocline_depth
+    real(dp)            :: ocean_linear_deep_temperature
+    real(dp)            :: ocean_linear_deep_salinity
+    real(dp)            :: ocean_linear_reference_depth
 
     ! Choice of realistic ocean model
     CHARACTER(LEN=256)  :: choice_ocean_model_realistic
@@ -2922,6 +2928,9 @@ CONTAINS
       choice_ocean_isomip_scenario_config                         , &
       ocean_tanh_deep_temperature_config                          , &
       ocean_tanh_thermocline_depth_config                         , &
+      ocean_linear_deep_temperature_config                        , &
+      ocean_linear_deep_salinity_config                           , &
+      ocean_linear_reference_depth_config                         , &
       choice_ocean_model_realistic_config                         , &
       filename_ocean_snapshot_NAM_config                          , &
       filename_ocean_snapshot_EAS_config                          , &
@@ -3926,6 +3935,9 @@ CONTAINS
     C%choice_ocean_isomip_scenario                           = choice_ocean_isomip_scenario_config
     C%ocean_tanh_deep_temperature                            = ocean_tanh_deep_temperature_config
     C%ocean_tanh_thermocline_depth                           = ocean_tanh_thermocline_depth_config
+    C%ocean_linear_deep_temperature                          = ocean_linear_deep_temperature_config
+    C%ocean_linear_deep_salinity                             = ocean_linear_deep_salinity_config
+    C%ocean_linear_reference_depth                           = ocean_linear_reference_depth_config
 
     ! Choice of realistic ocean model
     C%choice_ocean_model_realistic                           = choice_ocean_model_realistic_config

--- a/tools/python/colormaps.py
+++ b/tools/python/colormaps.py
@@ -49,24 +49,28 @@ def get_cmap(varname):
         norm = mpl.colors.Normalize(vmin=0,vmax=1000,clip=True)
 
     elif varname == 'H_lad':
-        cmap = copy(plt.get_cmap('gist_stern'))
-        norm = mpl.colors.Normalize(vmin=1,vmax=300,clip=True)
+        cmap = copy(plt.get_cmap('cmo.deep'))
+        norm = mpl.colors.LogNorm(vmin=1,vmax=200,clip=True)
 
-    elif varname == 'T_lad':
+    elif varname in ['T_lad', 'T_amb']:
         cmap = copy(plt.get_cmap('cmo.thermal'))
         norm = mpl.colors.Normalize(vmin=-2,vmax=1,clip=True)
 
-    elif varname == 'S_lad':
+    elif varname == 'T_base':
+        cmap = copy(plt.get_cmap('cmo.thermal'))
+        norm = mpl.colors.Normalize(vmin=-2,vmax=-1,clip=True)
+
+    elif varname in ['S_lad', 'S_amb']:
         cmap = copy(plt.get_cmap('cmo.haline'))
-        norm = mpl.colors.Normalize(vmin=32,vmax=34,clip=True)
+        norm = mpl.colors.Normalize(vmin=33,vmax=34.5,clip=True)
 
     elif varname in ['U_lad', 'V_lad']:
         cmap = copy(plt.get_cmap('cmo.balance'))
-        norm = mpl.colors.Normalize(vmin=-.2,vmax=.2,clip=True)
+        norm = mpl.colors.Normalize(vmin=-.5,vmax=.5,clip=True)
 
     elif varname in ['Uabs_lad']:
         cmap = copy(plt.get_cmap('Greens'))
-        norm = mpl.colors.Normalize(vmin=0,vmax=.2,clip=True)
+        norm = mpl.colors.Normalize(vmin=0,vmax=1.0,clip=True)
 
     elif varname in ['uabs_surf', 'uabs_vav']:
         cmap = copy(plt.get_cmap('turbo'))
@@ -80,6 +84,14 @@ def get_cmap(varname):
     elif varname == 'SGD':
         cmap = copy(plt.get_cmap('Blues'))
         norm = mpl.colors.Normalize(vmin=0,vmax=1e-5,clip=True)
+
+    elif varname == 'entr':
+        cmap = copy(plt.get_cmap('cmo.balance'))
+        norm = mpl.colors.Normalize(vmin=-1e-3,vmax=1e-3,clip=True)
+
+    elif varname == 'gamma_T':
+        cmap = copy(plt.get_cmap('Reds'))
+        norm = mpl.colors.Normalize(vmin=0,vmax=1e-4,clip=True)
 
     elif varname == 'mask':
         cmap = copy(plt.get_cmap('tab10'))


### PR DESCRIPTION
Fix Laddie's warm bias, by adding a missing vertical diffusive term in the heat budget.

Example: Left is Laddie 1, middle is previous version of Laddie 2 with parameters tuned down to partly suppress the warm bias. Right is the new version of Laddie 2 with the same parameters as Laddie 1:

<img width="1243" height="1090" alt="image" src="https://github.com/user-attachments/assets/1c59311b-d7af-4a02-8e7c-de0bf6fea90f" />

Still to be tested on a cold ice shelf.