### PR TITLE
Iceshelf scalars

### DIFF
--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:17:54</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.5724</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.5723</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.5722</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.572</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:17:56</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>9.2535e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.0404e-05</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.00011207</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.00014998</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:17:57</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.22294</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.42479</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.74691</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.087</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:17:58</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.9531</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.9531</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.953</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.953</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:00</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.3542e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0015207</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0030343</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0045392</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:01</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.21985</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>4.4874</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>8.9504</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>13.4051</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:02</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2308</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.2308</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.2307</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.2307</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:03</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.2019e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.002279</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0045468</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0068034</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:04</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.22041</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>4.4642</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>8.9057</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>13.339</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:05</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.5434</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.5434</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.5433</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.5432</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:06</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.1111e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0054681</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.010914</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.016339</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:08</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.18925</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.4783</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>6.9309</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>10.379</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:09</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>5.471</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.471</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.4709</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.4709</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:10</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3457e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0049488</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0098842</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.014806</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:12</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.2381</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.015</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9948</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.974</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:13</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.8226</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.8226</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.8225</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.8225</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:14</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3079e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0020247</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.004044</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.006058</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:16</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23949</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.9606</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.8862</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.8113</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:17</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.7709</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.7709</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.7708</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.7707</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:19</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3247e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0042416</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0084718</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.012691</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:20</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.2385</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.9866</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9378</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.8886</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:22</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.8497</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.8497</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.8496</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.8495</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:24</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3289e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0046293</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0092462</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.013851</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:25</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23831</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.0014</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9676</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.9332</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:26</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>7.3298</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>7.3298</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>7.3298</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>7.3297</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:28</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3373e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.00482</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.009627</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.014421</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:29</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23823</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.0105</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9858</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.9605</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:30</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.0983</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.0983</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.0983</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.0983</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:31</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0090051</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.017991</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.026958</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:32</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.31135</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.6359</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.2199</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>7.8075</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:33</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3326</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.3326</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.3326</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.3326</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:34</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0021267</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0042505</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0063716</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:35</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.42769</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.2308</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>4.3518</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>6.4847</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:37</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.0509</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.0509</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.0509</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.0509</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:38</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0072914</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.014574</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.021848</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:39</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.57588</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.0203</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.8555</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.716</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:40</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.3631</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.363</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.3629</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.3628</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:41</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.6269e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0054374</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.010846</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.016226</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic_97bd9fdba8c9fac853d1726bc2ada89b830240eb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>17-Aug-2025 11:18:42</date_and_time>
+    <git_hash_string>97bd9fdba8c9fac853d1726bc2ada89b830240eb</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.1601</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>4.1438</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>8.2687</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>12.3847</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_flowline_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_flowline_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_dHdt_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>17-Aug-2025 12:18:54</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.1507</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>3.4158</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.052501</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>13331</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>13331</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>844839</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_local_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_local_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_dHdt_local</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>17-Aug-2025 12:18:56</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.41802</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>8.4522</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.21455</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>21343</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>21343</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1395293</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_u_flowline_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_u_flowline_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_u_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>17-Aug-2025 12:18:57</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.46164</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>18.5146</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.08951</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>21329</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>21329</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1360630</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_dHdt_invfric_invBMB_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_dHdt_invfric_invBMB_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_dHdt_invfric_invBMB</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>17-Aug-2025 12:18:58</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.47488</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target [m]</definition>
+        <value>30.2662</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.11158</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_melt_rate</name>
+        <definition>95% of melt rates are within this range of its target [m/yr]</definition>
+        <value>3.8258</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>15045</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>15045</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1123754</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_flowline_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_flowline_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_dHdt_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>17-Aug-2025 11:41:50</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.039892</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>7.96</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.029714</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>7261</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>7305</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>188787</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_local_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_local_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_dHdt_local</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>17-Aug-2025 11:41:52</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.17785</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>44.9116</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.14388</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>12752</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>13276</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>235318</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_u_flowline_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_u_flowline_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_u_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>17-Aug-2025 11:41:53</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.091395</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>32.7461</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.068935</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>12342</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>12451</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>236629</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_10km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_10km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_10km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>17-Aug-2025 11:04:42</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>18.0239</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>1202</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_20km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_20km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_20km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>17-Aug-2025 11:04:41</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>22.7642</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>755</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_40km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_40km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_40km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>17-Aug-2025 11:04:40</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>34.8512</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>606</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_5km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_5km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_5km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>17-Aug-2025 11:04:43</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>14.6275</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>2571</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_10km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_10km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_10km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>17-Aug-2025 11:04:46</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>37.5749</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27490</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_20km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_20km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_20km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>17-Aug-2025 11:04:45</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>50.4243</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27480</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_40km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_40km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_40km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>17-Aug-2025 11:04:44</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>45.7239</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27378</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_5km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_5km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_5km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>17-Aug-2025 11:04:47</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>28.4531</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27494</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIP_mod_MISMIP_mod_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIP_mod_MISMIP_mod_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>MISMIP_mod</name>
+    <category>integrated_tests/idealised/MISMIP_mod</category>
+    <date_and_time>17-Aug-2025 11:09:35</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>GL_hyst_east</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>7089.9104</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_northeast</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>1813.8216</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_north</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>2057.1242</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_northwest</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>5660.0944</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_west</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>9375.9671</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_southwest</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>5371.2313</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_south</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>7083.9386</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_southeast</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>9601.2751</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>5939</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>5960</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>544735</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISMIPplus_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISMIPplus_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>MISMIPplus</name>
+    <category>integrated_tests/idealised/MISMIPplus</category>
+    <date_and_time>17-Aug-2025 11:31:45</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>err_x_GL_init</name>
+        <definition>abs( x_GL(1) - 450e3)</definition>
+        <value>716.0994</value>
+    </cost_functions>
+    <cost_functions>
+        <name>err_x_GL_final_lo</name>
+        <definition>abs( min( 0, x_GL( end) - 350e3))</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>err_x_GL_final_hi</name>
+        <definition>abs( max( 0, x_GL( end) - 420e3))</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>var_x_GL</name>
+        <definition>max( abs( x_GL_smooth - x_GL))</definition>
+        <value>927.4266</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>6596</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>6596</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>608865</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISOMIP_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISOMIP_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<single_run>
+    <name>MISOMIP</name>
+    <category>integrated_tests/idealised/MISMIPplus</category>
+    <date_and_time>2025-08-17 11:31:47</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>err_x_GL_final_lo</name>
+        <definition>abs( min( 0, x_GL[-1] - 430e3))</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>err_x_GL_final_hi</name>
+        <definition>abs( max( 0, x_GL[-1] - 450e3))</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_SSA_icestream_SSA_icestream_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_SSA_icestream_SSA_icestream_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>SSA_icestream</name>
+    <category>integrated_tests/idealised/SSA_icestream</category>
+    <date_and_time>17-Aug-2025 12:15:22</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>RMSE_32km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>400.4197</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_16km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>303.7011</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_8km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>151.9449</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_4km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>81.3852</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>1</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>727</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>782314</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_realistic_Antarctica_initialisation_Ant_init_20kyr_invBMB_invfric_40km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_realistic_Antarctica_initialisation_Ant_init_20kyr_invBMB_invfric_40km_a9e82b45897edf6756de2f095ea724abcc9dbdfa.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Ant_init_20kyr_invBMB_invfric_40km</name>
+    <category>integrated_tests/realistic/Antarctica/initialisation</category>
+    <date_and_time>17-Aug-2025 12:58:46</date_and_time>
+    <git_hash_string>a9e82b45897edf6756de2f095ea724abcc9dbdfa</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi( :,1)).^2 ))</definition>
+        <value>77.987</value>
+    </cost_functions>
+    <cost_functions>
+        <name>peak_volume_difference</name>
+        <definition>max( abs( ice_volume - ice_volume(1)))</definition>
+        <value>0.90421</value>
+    </cost_functions>
+    <cost_functions>
+        <name>final_volume_difference</name>
+        <definition>ice_volume( end) - ice_volume(1)</definition>
+        <value>0.20423</value>
+    </cost_functions>
+    <cost_functions>
+        <name>ice_volume_var</name>
+        <definition>max( ice_volume( last 5000 yr)) - min( ice_volume( last 5000 yr))</definition>
+        <value>0.017858</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>28112</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>32354</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>3659808</value>
+    </cost_functions>
+</single_run>

--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
@@ -145,25 +145,31 @@ contains
     call init_routine( routine_name)
 
     ! Initialise
-    scalars%ice_area      = 0._dp
-    scalars%ice_volume    = 0._dp
-    scalars%ice_volume_af = 0._dp
+    scalars%ice_area         = 0._dp
+    scalars%ice_volume       = 0._dp
+    scalars%ice_volume_af    = 0._dp
+    scalars%ice_shelf_area   = 0._dp
+    scalars%ice_shelf_volume = 0._dp
 
     ! Calculate ice area and volume for each process
     do vi = mesh%vi1, mesh%vi2
 
       if (ice%mask_grounded_ice( vi) .or. ice%mask_floating_ice( vi)) then
-        scalars%ice_volume    = scalars%ice_volume    + max( 0._dp, (ice%Hi( vi) * mesh%A( vi) * ice_density / (seawater_density * ocean_area)))
-        scalars%ice_area      = scalars%ice_area      + mesh%A( vi) * 1.0E-06_dp ! [km^2]
-        scalars%ice_volume_af = scalars%ice_volume_af + max( 0._dp, ice%TAF( vi) * mesh%A( vi) * ice_density / (seawater_density * ocean_area))
+        scalars%ice_volume       = scalars%ice_volume       + max( 0._dp, (ice%Hi( vi) * mesh%A( vi) * ice_density / (seawater_density * ocean_area)))
+        scalars%ice_area         = scalars%ice_area         + mesh%A( vi) * 1.0E-06_dp ! [km^2]
+        scalars%ice_volume_af    = scalars%ice_volume_af    + max( 0._dp, ice%TAF( vi) * mesh%A( vi) * ice_density / (seawater_density * ocean_area))
+        scalars%ice_shelf_area   = scalars%ice_shelf_area   + mesh%A( vi) * (1._dp - ice%fraction_gr( vi)) * 1.0E-06_dp ! [km^2]
+        scalars%ice_shelf_volume = scalars%ice_shelf_volume + max( 0._dp, (ice%Hi( vi) * mesh%A( vi) * (1._dp - ice%fraction_gr( vi)) * 1.0E-09_dp ![km^3]
       end if
 
     end do
 
     ! Add together values from each process
-    call MPI_ALLREDUCE( MPI_IN_PLACE, scalars%ice_area,      1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
-    call MPI_ALLREDUCE( MPI_IN_PLACE, scalars%ice_volume,    1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
-    call MPI_ALLREDUCE( MPI_IN_PLACE, scalars%ice_volume_af, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
+    call MPI_ALLREDUCE( MPI_IN_PLACE, scalars%ice_area,         1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
+    call MPI_ALLREDUCE( MPI_IN_PLACE, scalars%ice_volume,       1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
+    call MPI_ALLREDUCE( MPI_IN_PLACE, scalars%ice_volume_af,    1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
+    call MPI_ALLREDUCE( MPI_IN_PLACE, scalars%ice_shelf_area,   1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
+    call MPI_ALLREDUCE( MPI_IN_PLACE, scalars%ice_shelf_volume, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
 
     ! Finalise routine path
     call finalise_routine( routine_name)

--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
@@ -159,7 +159,7 @@ contains
         scalars%ice_area         = scalars%ice_area         + mesh%A( vi) * 1.0E-06_dp ! [km^2]
         scalars%ice_volume_af    = scalars%ice_volume_af    + max( 0._dp, ice%TAF( vi) * mesh%A( vi) * ice_density / (seawater_density * ocean_area))
         scalars%ice_shelf_area   = scalars%ice_shelf_area   + mesh%A( vi) * (1._dp - ice%fraction_gr( vi)) * 1.0E-06_dp ! [km^2]
-        scalars%ice_shelf_volume = scalars%ice_shelf_volume + max( 0._dp, (ice%Hi( vi) * mesh%A( vi) * (1._dp - ice%fraction_gr( vi)) * 1.0E-09_dp ![km^3]
+        scalars%ice_shelf_volume = scalars%ice_shelf_volume + max( 0._dp, (ice%Hi( vi) * mesh%A( vi) * (1._dp - ice%fraction_gr( vi))) * 1.0E-09_dp ![km^3]
       end if
 
     end do

--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
@@ -159,7 +159,7 @@ contains
         scalars%ice_area         = scalars%ice_area         + mesh%A( vi) * 1.0E-06_dp ! [km^2]
         scalars%ice_volume_af    = scalars%ice_volume_af    + max( 0._dp, ice%TAF( vi) * mesh%A( vi) * ice_density / (seawater_density * ocean_area))
         scalars%ice_shelf_area   = scalars%ice_shelf_area   + mesh%A( vi) * (1._dp - ice%fraction_gr( vi)) * 1.0E-06_dp ! [km^2]
-        scalars%ice_shelf_volume = scalars%ice_shelf_volume + max( 0._dp, (ice%Hi( vi) * mesh%A( vi) * (1._dp - ice%fraction_gr( vi))) * 1.0E-09_dp ![km^3]
+        scalars%ice_shelf_volume = scalars%ice_shelf_volume + max( 0._dp, (ice%Hi( vi) * mesh%A( vi) * (1._dp - ice%fraction_gr( vi)))) * 1.0E-09_dp ! [km^3]
       end if
 
     end do

--- a/src/UFEMISM/io/main_regional_output/scalar_output_files.f90
+++ b/src/UFEMISM/io/main_regional_output/scalar_output_files.f90
@@ -66,6 +66,11 @@ contains
     call write_buffer_to_scalar_file_single_variable( filename, ncid, 'ice_volume_PD',     region%scalars%buffer%ice_volume_PD,     n, ti+1)
     call write_buffer_to_scalar_file_single_variable( filename, ncid, 'ice_volume_af_PD',  region%scalars%buffer%ice_volume_af_PD,  n, ti+1)
 
+    ! Integrated ice shelf geometry
+    call write_buffer_to_scalar_file_single_variable( filename, ncid, 'ice_shelf_area',    region%scalars%buffer%ice_shelf_area,    n, ti+1)
+    call write_buffer_to_scalar_file_single_variable( filename, ncid, 'ice_shelf_volume',  region%scalars%buffer%ice_shelf_volume,  n, ti+1)
+
+
     ! Integrated mass fluxes
     call write_buffer_to_scalar_file_single_variable( filename, ncid, 'SMB_total',         region%scalars%buffer%SMB_total,         n, ti+1)
     call write_buffer_to_scalar_file_single_variable( filename, ncid, 'SMB_gr',            region%scalars%buffer%SMB_gr,            n, ti+1)
@@ -154,6 +159,10 @@ contains
     call add_field_dp_0D( filename, ncid, 'ice_volume_PD',     long_name = 'Total ice volume for present-day', units = 'm s.l.e.')
     call add_field_dp_0D( filename, ncid, 'ice_volume_af_PD',  long_name = 'Total ice volume above floatation for present-day', units = 'm s.l.e.')
 
+    ! Integrated ice shelf geometry
+    call add_field_dp_0D( filename, ncid, 'ice_shelf_area',    long_name = 'Total ice shelf area', units = 'km^2')
+    call add_field_dp_0D( filename, ncid, 'ice_shelf_volume',  long_name = 'Total ice shelf volume', units = 'km^3')
+
     ! Integrated mass fluxes
     call add_field_dp_0D( filename, ncid, 'SMB_total',         long_name = 'Area-integrated total SMB', units = 'Gt yr^-1')
     call add_field_dp_0D( filename, ncid, 'SMB_gr',            long_name = 'Area-integrated ice sheet SMB', units = 'Gt yr^-1')
@@ -231,6 +240,9 @@ contains
       allocate( region%scalars%buffer%ice_volume_PD    ( n_mem), source = 0._dp)
       allocate( region%scalars%buffer%ice_volume_af_PD ( n_mem), source = 0._dp)
 
+      allocate( region%scalars%buffer%ice_shelf_area   ( n_mem), source = 0._dp)
+      allocate( region%scalars%buffer%ice_shelf_volume ( n_mem), source = 0._dp)
+
       allocate( region%scalars%buffer%SMB_total        ( n_mem), source = 0._dp)
       allocate( region%scalars%buffer%SMB_gr           ( n_mem), source = 0._dp)
       allocate( region%scalars%buffer%SMB_fl           ( n_mem), source = 0._dp)
@@ -303,6 +315,9 @@ contains
       region%scalars%buffer%ice_volume_PD    ( n) = region%scalars%ice_volume_PD
       region%scalars%buffer%ice_volume_af_PD ( n) = region%scalars%ice_volume_af_PD
 
+      region%scalars%buffer%ice_shelf_area   ( n) = region%scalars%ice_shelf_area
+      region%scalars%buffer%ice_shelf_volume ( n) = region%scalars%ice_shelf_volume
+
       region%scalars%buffer%SMB_total        ( n) = region%scalars%SMB_total
       region%scalars%buffer%SMB_gr           ( n) = region%scalars%SMB_gr
       region%scalars%buffer%SMB_fl           ( n) = region%scalars%SMB_fl
@@ -367,6 +382,9 @@ contains
     call reallocate( region%scalars%buffer%ice_area_PD      , n_mem, source = 0._dp)
     call reallocate( region%scalars%buffer%ice_volume_PD    , n_mem, source = 0._dp)
     call reallocate( region%scalars%buffer%ice_volume_af_PD , n_mem, source = 0._dp)
+
+    call reallocate( region%scalars%buffer%ice_shelf_area   , n_mem, source = 0._dp)
+    call reallocate( region%scalars%buffer%ice_shelf_volume , n_mem, source = 0._dp)
 
     call reallocate( region%scalars%buffer%SMB_total        , n_mem, source = 0._dp)
     call reallocate( region%scalars%buffer%SMB_gr           , n_mem, source = 0._dp)

--- a/src/UFEMISM/types/scalar_types.f90
+++ b/src/UFEMISM/types/scalar_types.f90
@@ -23,6 +23,9 @@ module scalar_types
     real(dp), dimension(:), allocatable :: ice_volume_PD
     real(dp), dimension(:), allocatable :: ice_volume_af_PD
 
+    real(dp), dimension(:), allocatable :: ice_shelf_area
+    real(dp), dimension(:), allocatable :: ice_shelf_volume
+
     real(dp), dimension(:), allocatable :: SMB_total
     real(dp), dimension(:), allocatable :: SMB_gr
     real(dp), dimension(:), allocatable :: SMB_fl
@@ -68,6 +71,10 @@ module scalar_types
     real(dp)   :: ice_volume_af            ! [m SLE]    Total ice sheet volume above floatation
     real(dp)   :: ice_volume_af_PD         ! [m SLE]    Total present-day ice sheet volume above floatation
     real(dp)   :: sea_level_contribution   ! [m SLE]    Total contribution to global mean sea level
+
+    ! Ice shelf geometry
+    real(dp)   :: ice_shelf_area           ! [km^2]     Total ice shelf area
+    real(dp)   :: ice_shelf_volume         ! [km^3]     Total ice shelf volume
 
     ! Integrated fluxes
     real(dp)   :: SMB_total                ! [Gt yr^-1] Area-integrated surface mass balance


### PR DESCRIPTION
Add ice shelf scalars (total area and volume) to the UFEMISM scalar output. Useful for tuning / optimising basal melt models