### PR TITLE
Bug fix: Properly closing NetCDF file after reading

### DIFF
--- a/src/UPSY/io/read_and_remap/read_and_remap_field_from_file.f90
+++ b/src/UPSY/io/read_and_remap/read_and_remap_field_from_file.f90
@@ -781,6 +781,8 @@ contains
 
     end if ! if (present( time_to_read)) then
 
+    call close_netcdf_file( ncid)
+
     ! Finalise routine path
     call finalise_routine( routine_name)
 


### PR DESCRIPTION
The function "read_field_from_file_0D" was not closing the NetCDF file, which could throw "too many open files" errors, and likely also causing too much memory to be used. The file is now being properly closed, which should solve this issue.