### PR TITLE
add ustar in uniform gamma

### DIFF
--- a/src/LADDIE/laddie_physics.f90
+++ b/src/LADDIE/laddie_physics.f90
@@ -57,8 +57,12 @@ CONTAINS
       CASE DEFAULT
         CALL crash('unknown choice_laddie_gamma "' // TRIM( C%choice_laddie_gamma) // '"')
       CASE ('uniform')
-        laddie%gamma_T( mesh%vi1:mesh%vi2) = C%uniform_laddie_gamma_T
-        laddie%gamma_S( mesh%vi1:mesh%vi2) = C%uniform_laddie_gamma_T/35.0_dp
+        do vi = mesh%vi1, mesh%vi2
+          if (laddie%mask_a( vi)) then
+            laddie%gamma_T( vi) = laddie%u_star( vi) * C%uniform_laddie_gamma_T
+            laddie%gamma_S( vi) = laddie%u_star( vi) * C%uniform_laddie_gamma_T/35.0_dp
+          end if
+        end do
       CASE ('Jenkins1991')
         DO vi = mesh%vi1, mesh%vi2
            IF (laddie%mask_a( vi)) THEN


### PR DESCRIPTION
The uniform gamma option in LADDIE missed a multiplication with u_star. This is now corrected. The input value of gamma_T is now unitless and comparable with 3D ocean models in the ISOMIP+ setting.

