### PR TITLE
Add scale depth config parameter for ocean idealised TANH

### DIFF
--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:49:45</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.6323</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:49:47</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>9.2535e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:49:48</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.22294</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:49:48</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.0218</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:49:49</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.3542e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:49:50</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.21985</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:49:51</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2827</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:49:52</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.2019e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:49:53</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.22041</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:49:54</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.5793</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:49:55</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.1111e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:49:55</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.18925</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:49:56</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>5.5983</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:49:57</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3457e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:49:58</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.2381</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:49:59</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.9115</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:00</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3079e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:01</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23949</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:02</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.8121</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:03</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3247e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:04</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.2385</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:05</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.8928</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:06</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3289e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:06</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23831</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:07</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>7.5003</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:08</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3373e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:09</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23823</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:10</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.1471</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:11</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:12</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.31135</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:13</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3869</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:14</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:15</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.42769</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:15</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.0753</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:16</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:17</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.57588</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:18</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.4413</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:19</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.6269e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic_b15f01747d7002efd8729a3d13b2df85116845b5.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>30-Sep-2025 08:50:20</date_and_time>
+    <git_hash_string>b15f01747d7002efd8729a3d13b2df85116845b5</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.1601</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value></value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_flowline_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_flowline_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_dHdt_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>30-Sep-2025 09:59:22</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>2.8243</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>871.8878</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>74.035</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>14725</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>14725</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>658078</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_local_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_local_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_dHdt_local</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>30-Sep-2025 09:59:23</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>2.8823</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>858.8779</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>72.6795</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>21373</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>21373</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>868119</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_u_flowline_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_u_flowline_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_u_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>30-Sep-2025 09:59:24</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>7.9985</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>852.9168</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>73.9615</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>21035</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>21035</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>631877</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_dHdt_invfric_invBMB_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_dHdt_invfric_invBMB_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_dHdt_invfric_invBMB</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>30-Sep-2025 09:59:25</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.51023</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target [m]</definition>
+        <value>14.4026</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.11941</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_melt_rate</name>
+        <definition>95% of melt rates are within this range of its target [m/yr]</definition>
+        <value>2.3182</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>15453</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>15453</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>596494</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_flowline_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_flowline_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_dHdt_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>30-Sep-2025 09:32:53</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.020494</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>3.4158</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.012632</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>6864</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>6894</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>109138</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_local_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_local_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_dHdt_local</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>30-Sep-2025 09:32:54</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.18102</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>48.3679</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.17688</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>12555</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>12902</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>120517</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_u_flowline_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_u_flowline_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_u_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>30-Sep-2025 09:32:55</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.09834</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>31.9117</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.090118</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>12448</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>12482</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>142074</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_10km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_10km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_10km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>30-Sep-2025 08:45:55</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>18.7849</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>1213</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_20km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_20km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_20km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>30-Sep-2025 08:45:53</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>22.6335</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>764</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_40km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_40km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_40km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>30-Sep-2025 08:45:51</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>35.1325</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>601</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_5km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_5km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_5km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>30-Sep-2025 08:45:56</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>13.3881</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>2647</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_10km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_10km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_10km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>30-Sep-2025 08:46:01</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>37.5962</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27490</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_20km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_20km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_20km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>30-Sep-2025 08:45:59</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>50.4591</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27467</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_40km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_40km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_40km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>30-Sep-2025 08:45:57</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>45.752</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27383</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_5km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_5km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_5km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>30-Sep-2025 08:46:02</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>28.47</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27494</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIP_mod_MISMIP_mod_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIP_mod_MISMIP_mod_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>MISMIP_mod</name>
+    <category>integrated_tests/idealised/MISMIP_mod</category>
+    <date_and_time>30-Sep-2025 08:52:31</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>GL_hyst_east</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>6627.6904</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_northeast</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>7792.57</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_north</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>590.6388</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_northwest</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>8376.9745</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_west</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>6810.2902</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_southwest</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>6814.4199</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_south</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>13590.5528</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_southeast</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>7063.0899</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>5772</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>5789</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>146534</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISMIPplus_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISMIPplus_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>MISMIPplus</name>
+    <category>integrated_tests/idealised/MISMIPplus</category>
+    <date_and_time>30-Sep-2025 09:53:26</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>err_x_GL_init</name>
+        <definition>abs( x_GL(1) - 450e3)</definition>
+        <value>792.421</value>
+    </cost_functions>
+    <cost_functions>
+        <name>err_x_GL_final_lo</name>
+        <definition>abs( min( 0, x_GL( end) - 350e3))</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>err_x_GL_final_hi</name>
+        <definition>abs( max( 0, x_GL( end) - 420e3))</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>var_x_GL</name>
+        <definition>max( abs( x_GL_smooth - x_GL))</definition>
+        <value>711.6448</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>6670</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>6670</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>490917</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISOMIP_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISOMIP_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<single_run>
+    <name>MISOMIP</name>
+    <category>integrated_tests/idealised/MISMIPplus</category>
+    <date_and_time>2025-09-30 09:53:28</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>err_x_GL_final_lo</name>
+        <definition>abs( min( 0, x_GL[-1] - 430e3))</definition>
+        <value>3470.3095</value>
+    </cost_functions>
+    <cost_functions>
+        <name>err_x_GL_final_hi</name>
+        <definition>abs( max( 0, x_GL[-1] - 450e3))</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_SSA_icestream_SSA_icestream_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_SSA_icestream_SSA_icestream_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>SSA_icestream</name>
+    <category>integrated_tests/idealised/SSA_icestream</category>
+    <date_and_time>30-Sep-2025 09:03:53</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>RMSE_32km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>384.8383</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_16km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>283.2362</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_8km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>127.1982</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_4km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>75.0758</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>1</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>524</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>249741</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_realistic_Antarctica_initialisation_Ant_init_20kyr_invBMB_invfric_40km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_realistic_Antarctica_initialisation_Ant_init_20kyr_invBMB_invfric_40km_b340f23b4f2cea2af1020f336633a84420bdd4be.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Ant_init_20kyr_invBMB_invfric_40km</name>
+    <category>integrated_tests/realistic/Antarctica/initialisation</category>
+    <date_and_time>30-Sep-2025 10:50:52</date_and_time>
+    <git_hash_string>b340f23b4f2cea2af1020f336633a84420bdd4be</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi( :,1)).^2 ))</definition>
+        <value>73.3682</value>
+    </cost_functions>
+    <cost_functions>
+        <name>peak_volume_difference</name>
+        <definition>max( abs( ice_volume - ice_volume(1)))</definition>
+        <value>0.95898</value>
+    </cost_functions>
+    <cost_functions>
+        <name>final_volume_difference</name>
+        <definition>ice_volume( end) - ice_volume(1)</definition>
+        <value>0.23497</value>
+    </cost_functions>
+    <cost_functions>
+        <name>ice_volume_var</name>
+        <definition>max( ice_volume( last 5000 yr)) - min( ice_volume( last 5000 yr))</definition>
+        <value>0.02689</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>30747</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>31084</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>4118523</value>
+    </cost_functions>
+</single_run>

--- a/src/UFEMISM/ocean/ocean_idealised.f90
+++ b/src/UFEMISM/ocean/ocean_idealised.f90
@@ -157,7 +157,6 @@ CONTAINS
     CHARACTER(LEN=256), PARAMETER                       :: routine_name = 'initialise_ocean_model_idealised_TANH'
     INTEGER                                             :: vi
     INTEGER                                             :: k
-    REAL(dp), PARAMETER                                 :: z1 = 100.0_dp   ! [m] Depth scale for thermocline sharpness
     REAL(dp), PARAMETER                                 :: drho0 = 0.01_dp ! [kg m^-5] Density scale factor to set quadratic stratification
     REAL(dp), PARAMETER                                 :: S0 = 34.0_dp    ! [PSU]  Surface salinity
     REAL(dp)                                            :: Tsurf           ! [deg C]  Surface freezing temperature
@@ -171,7 +170,7 @@ CONTAINS
 
       DO k = 1, C%nz_ocean
         ! Get temperature value
-        ocean%T( vi, k) = Tsurf + (C%ocean_tanh_deep_temperature-Tsurf) * (1+tanh((C%z_ocean( k)-C%ocean_tanh_thermocline_depth)/z1))/2
+        ocean%T( vi, k) = Tsurf + (C%ocean_tanh_deep_temperature-Tsurf) * (1+tanh((C%z_ocean( k)-C%ocean_tanh_thermocline_depth)/C%ocean_tanh_thermocline_scale_depth))/2
 
         ! Get salinity value at this depth based on quadratic density profile and linear equation of state
         ocean%S( vi, k) = S0 + C%uniform_laddie_eos_linear_alpha * (ocean%T( vi, k)-Tsurf)/C%uniform_laddie_eos_linear_beta &

--- a/src/UPSY/basic/model_configuration.f90
+++ b/src/UPSY/basic/model_configuration.f90
@@ -703,6 +703,7 @@ MODULE model_configuration
     CHARACTER(LEN=256)  :: choice_ocean_isomip_scenario_config          = ''                               ! Scenario when using 'ISOMIP' forcing: 'WARM' or 'COLD'
     REAL(dp)            :: ocean_tanh_deep_temperature_config           = 1.0_dp                           ! [degC] Deep ocean temperature when using 'TANH' forcing
     REAL(dp)            :: ocean_tanh_thermocline_depth_config          = 100.0_dp                         ! [m]    Depth of thermocline when using 'TANH' forcing
+    REAL(dp)            :: ocean_tanh_thermocline_scale_depth_config    = 100.0_dp                         ! [m]    Scale depth for thermocline sharpness when using 'TANH' forcing
     real(dp)            :: ocean_linear_deep_temperature_config         = -2.3_dp                          ! [degC] Deep ocean temperature when using 'LINEAR' forcing
     real(dp)            :: ocean_linear_deep_salinity_config            = 34.8_dp                          ! [psu] Deep ocean salinity when using 'LINEAR' forcing
     real(dp)            :: ocean_linear_reference_depth_config          = 2000.0_dp                        ! [m] Depth where deep values are prescribed
@@ -1832,6 +1833,7 @@ MODULE model_configuration
     CHARACTER(LEN=256)  :: choice_ocean_isomip_scenario
     REAL(dp)            :: ocean_tanh_deep_temperature
     REAL(dp)            :: ocean_tanh_thermocline_depth
+    REAL(dp)            :: ocean_tanh_thermocline_scale_depth
     real(dp)            :: ocean_linear_deep_temperature
     real(dp)            :: ocean_linear_deep_salinity
     real(dp)            :: ocean_linear_reference_depth
@@ -2937,6 +2939,7 @@ CONTAINS
       choice_ocean_isomip_scenario_config                         , &
       ocean_tanh_deep_temperature_config                          , &
       ocean_tanh_thermocline_depth_config                         , &
+      ocean_tanh_thermocline_scale_depth_config                   , &
       ocean_linear_deep_temperature_config                        , &
       ocean_linear_deep_salinity_config                           , &
       ocean_linear_reference_depth_config                         , &
@@ -3946,6 +3949,7 @@ CONTAINS
     C%choice_ocean_isomip_scenario                           = choice_ocean_isomip_scenario_config
     C%ocean_tanh_deep_temperature                            = ocean_tanh_deep_temperature_config
     C%ocean_tanh_thermocline_depth                           = ocean_tanh_thermocline_depth_config
+    C%ocean_tanh_thermocline_scale_depth                     = ocean_tanh_thermocline_scale_depth_config
     C%ocean_linear_deep_temperature                          = ocean_linear_deep_temperature_config
     C%ocean_linear_deep_salinity                             = ocean_linear_deep_salinity_config
     C%ocean_linear_reference_depth                           = ocean_linear_reference_depth_config


### PR DESCRIPTION
Replaced the hardcoded scale depth 'z1' from computation TANH profile by flexible config parameter. Default is still 100 m.