### PR TITLE
Add ISMIP7 shelf collapse forcing

### DIFF
--- a/src/UFEMISM/ISMIP7_forcing/ISMIP7_fracture.f90
+++ b/src/UFEMISM/ISMIP7_forcing/ISMIP7_fracture.f90
@@ -1,0 +1,21 @@
+module ISMIP7_fracture
+
+  ! The ISMIP7 protocol provides a single NetCDF file containing a mask
+  ! for every year (1950-2299). The mask is integer-valued (as NetCDF
+  ! doesn't support logicals), with 1 indicating fracture, implying
+  ! that no (floating?) ice is allowed to exist there anymore.
+
+  ! This setting is controlled by the config parameter 'do_apply_ISMIP7_fracture_mask_config'
+
+  use precisions, only: dp
+  use model_configuration, only: C
+  use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine
+  use crash_mod, only: crash
+
+  implicit none
+
+  private
+
+contains
+
+end module ISMIP7_fracture

--- a/src/UFEMISM/ISMIP7_forcing/ISMIP7_fracture.f90
+++ b/src/UFEMISM/ISMIP7_forcing/ISMIP7_fracture.f90
@@ -11,11 +11,238 @@ module ISMIP7_fracture
   use model_configuration, only: C
   use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine
   use crash_mod, only: crash
+  use models_basic, only: atype_model
+  use mesh_types, only: type_mesh
+  use mpi_f08, only: MPI_WIN
+  use Arakawa_grid_mod, only: Arakawa_grid
+  use netcdf_io_main, only: read_time_from_file, open_existing_netcdf_file_for_reading, &
+    setup_xy_grid_from_file, close_netcdf_file, inquire_var, read_var_primary
+  use grid_types, only: type_grid
+  use remapping_types, only: type_map
+  use remapping_grid_to_mesh_vertices, only: create_map_from_xy_grid_to_mesh_vertices
+  use apply_maps, only: apply_map_xy_grid_to_mesh_2D
+  use UPSY_main, only: UPSY
+  use mpi_basic, only: par
+  use mpi_distributed_memory_grid, only: distribute_gridded_data_from_primary
+  use dist_to_hybrid_mod, only: dist_to_hybrid
 
   implicit none
 
   private
 
+  public :: type_ISMIP7_fracture_model
+
+  type, extends(atype_model) :: type_ISMIP7_fracture_model
+
+      character(len=:), allocatable               :: filename
+      real(dp), dimension(:), allocatable         :: time_in_file              ! List of timeframes in the NetCDF file
+
+      type(type_grid)                             :: grid_raw                  ! The x/y-grid that the ISMIP7 folks provided the data on
+      type(type_map)                              :: map                       ! Mapping object to remap data from the ISMIP7 grid to the UFEMISM mesh
+
+      real(dp)                                    :: t0, t1                    ! Timestamps of enveloping timeframes
+      real(dp), dimension(:), contiguous, pointer :: mask_dp_t0   => null()    ! Left  enveloping timeframe
+      real(dp), dimension(:), contiguous, pointer :: mask_dp_t1   => null()    ! Right enveloping timeframe
+      type(MPI_WIN) :: wmask_dp_t0, wmask_dp_t1
+
+    contains
+
+      procedure, public :: get_model_name
+      procedure, public :: allocate   => ISMIP7_fracture_model_allocate
+      procedure, public :: initialise => ISMIP7_fracture_model_initialise
+
+      procedure, private :: initialise_remapping_object
+      procedure, private :: update_timeframes
+      procedure, private :: read_single_timeframe_from_netcdf
+
+  end type type_ISMIP7_fracture_model
+
 contains
+
+  subroutine ISMIP7_fracture_model_allocate( self, region_name, mesh)
+
+    ! In/output variables:
+    class(type_ISMIP7_fracture_model), intent(inout) :: self
+    character(len=*),                  intent(in   ) :: region_name
+    type(type_mesh), target,           intent(in   ) :: mesh
+
+    ! Local variables:
+    character(len=*), parameter :: routine_name = 'ISMIP7_fracture_model_allocate'
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Allocate all the stuff that is common to all models
+    call self%allocate_model( region_name, mesh)
+
+    ! Allocate all the stuff that is specific to the ISMIP7 mask-based hydrofracture model
+    call self%create_field( self%mask_dp_t0, self%wmask_dp_t0, &
+      self%mesh, Arakawa_grid%a(), &
+      name      = 'mask_dp_t0', &
+      long_name = 'ISMIP7 hydrofracture mask at previous timeframe', &
+      units     = '0-1', &
+      remap_method = 'reallocate')
+
+    call self%create_field( self%mask_dp_t1, self%wmask_dp_t1, &
+      self%mesh, Arakawa_grid%a(), &
+      name      = 'mask_dp_t1', &
+      long_name = 'ISMIP7 hydrofracture mask at next timeframe', &
+      units     = '0-1', &
+      remap_method = 'reallocate')
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine ISMIP7_fracture_model_allocate
+
+  subroutine ISMIP7_fracture_model_initialise( self)
+
+    ! In/output variables:
+    class(type_ISMIP7_fracture_model), intent(inout) :: self
+
+    ! Local variables:
+    character(len=*), parameter   :: routine_name = 'ISMIP7_fracture_model_initialise'
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    self%filename = C%filename_ISMIP7_fracture_mask
+
+    if (par%primary) write(0,*) '  Initialising ISMIP7 mask-based hydrofracture model from file "', &
+      UPSY%stru%colour_string( trim( self%filename), 'light blue'), '"...'
+
+    call self%initialise_remapping_object()
+
+    call read_time_from_file( self%filename, self%time_in_file)
+
+    self%t0 = C%start_time_of_run - 2._dp
+    self%t1 = C%start_time_of_run - 1._dp
+    call self%update_timeframes( C%start_time_of_run)
+
+    call crash('whoopsiedaisy')
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine ISMIP7_fracture_model_initialise
+
+  subroutine initialise_remapping_object( self)
+
+    ! In/output variables
+    class(type_ISMIP7_fracture_model), intent(inout) :: self
+
+    ! Local variables:
+    character(len=*), parameter   :: routine_name = 'initialise_remapping_object'
+    integer                       :: ncid
+
+    ! Add routine to path
+    call init_routine( routine_name)
+
+    ! Read the grid from the first listed input file
+    call open_existing_netcdf_file_for_reading( self%filename, ncid)
+    call setup_xy_grid_from_file( self%filename, ncid, self%grid_raw)
+    call close_netcdf_file( ncid)
+
+    ! Calculate the remapping operator
+    self%grid_raw%name = 'ISMIP7_input_grid_' // trim( self%name())
+    call create_map_from_xy_grid_to_mesh_vertices( self%grid_raw, self%mesh, C%output_dir, self%map, '2nd_order_conservative')
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  end subroutine initialise_remapping_object
+
+  subroutine update_timeframes( self, time)
+
+    ! In/output variables:
+    class(type_ISMIP7_fracture_model), intent(inout) :: self
+    real(dp),                          intent(in   ) :: time
+
+    ! Local variables:
+    character(len=*), parameter :: routine_name = 'update_timeframes'
+    integer                     :: ti0, ti1
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Determine which timeframes to read
+    ti0 = 1
+    ti1 = 2
+    do while (self%time_in_file( ti1) < time .and. ti1 < size( self%time_in_file,1))
+      ti0 = ti1
+      ti1 = ti1 + 1
+    end do
+
+    self%t0 = self%time_in_file( ti0)
+    self%t1 = self%time_in_file( ti1)
+
+    call self%read_single_timeframe_from_netcdf( ti0, self%mask_dp_t0)
+    call self%read_single_timeframe_from_netcdf( ti1, self%mask_dp_t1)
+
+    call crash('whoopsiedaisy')
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine update_timeframes
+
+  subroutine read_single_timeframe_from_netcdf( self, ti, mask_dp)
+
+    ! In/output variables:
+    class(type_ISMIP7_fracture_model), intent(in   ) :: self
+    integer,                           intent(in   ) :: ti
+    real(dp), dimension(:),            intent(inout) :: mask_dp
+
+    ! Local variables
+    character(len=*), parameter                      :: routine_name = 'read_single_timeframe_from_netcdf'
+    integer,  dimension(:,:,:), allocatable          :: mask_grid_tot_with_time
+    real(dp), dimension(:,:  ), allocatable          :: mask_grid_dp_tot
+    integer                                          :: ncid, id_var
+    real(dp), dimension(:    ), allocatable          :: mask_grid_dp_vec_partial
+    real(dp), dimension(self%mesh%vi1:self%mesh%vi2) :: mask_dp_dist
+
+    ! Add routine to path
+    call init_routine( routine_name)
+
+    if (par%primary) then
+      write(0,'(A,I4,A,A,A)') '   Reading ISMIP7 hydrofracture mask for year ', floor( self%time_in_file( ti)), ' from file "', &
+        UPSY%stru%colour_string( trim( self%filename), 'light blue'), '"...'
+    end if
+
+    ! Read raw gridded data to the primary
+    if (par%primary) then
+      allocate( mask_grid_tot_with_time( self%grid_raw%nx, self%grid_raw%ny, 1))
+      allocate( mask_grid_dp_tot       ( self%grid_raw%nx, self%grid_raw%ny   ))
+    else
+      allocate( mask_grid_tot_with_time(0,0,0))
+      allocate( mask_grid_dp_tot       (0,0  ))
+    end if
+
+    call open_existing_netcdf_file_for_reading( self%filename, ncid)
+    call inquire_var( self%filename, ncid, 'mask', id_var)
+    call read_var_primary( self%filename, ncid, id_var, mask_grid_tot_with_time)
+    if (par%primary) mask_grid_dp_tot = real( mask_grid_tot_with_time( :,:,1), dp)
+    deallocate( mask_grid_tot_with_time)
+    call close_netcdf_file( ncid)
+
+    ! Distribute gridded data to the processes
+    allocate( mask_grid_dp_vec_partial( self%grid_raw%pai%i1: self%grid_raw%pai%i2))
+    call distribute_gridded_data_from_primary( self%grid_raw, mask_grid_dp_vec_partial, mask_grid_dp_tot)
+    deallocate( mask_grid_dp_tot)
+
+    ! Remap data to mesh
+    call apply_map_xy_grid_to_mesh_2D( self%grid_raw, self%mesh, self%map, mask_grid_dp_vec_partial, mask_dp_dist)
+    call dist_to_hybrid( self%mesh%pai_V, mask_dp_dist, mask_dp)
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  end subroutine read_single_timeframe_from_netcdf
+
+  function get_model_name( self) result( model_name)
+    class(type_ISMIP7_fracture_model), intent(in) :: self
+    character(len=:), allocatable :: model_name
+    model_name = 'ISMIP7_fracture'
+  end function get_model_name
 
 end module ISMIP7_fracture

--- a/src/UFEMISM/ISMIP7_forcing/ISMIP7_fracture.f90
+++ b/src/UFEMISM/ISMIP7_forcing/ISMIP7_fracture.f90
@@ -145,7 +145,7 @@ contains
 
     ! Calculate the remapping operator
     self%grid_raw%name = 'ISMIP7_input_grid_' // trim( self%name())
-    call create_map_from_xy_grid_to_mesh_vertices( self%grid_raw, self%mesh, C%output_dir, self%map, '2nd_order_conservative')
+    call create_map_from_xy_grid_to_mesh_vertices( self%grid_raw, self%mesh, C%output_dir, self%map, '1st_order_conservative')
 
     ! Finalise routine path
     call finalise_routine( routine_name)
@@ -179,8 +179,6 @@ contains
     call self%read_single_timeframe_from_netcdf( ti0, self%mask_dp_t0)
     call self%read_single_timeframe_from_netcdf( ti1, self%mask_dp_t1)
 
-    call crash('whoopsiedaisy')
-
     ! Remove routine from call stack
     call finalise_routine( routine_name)
 
@@ -200,6 +198,7 @@ contains
     integer                                          :: ncid, id_var
     real(dp), dimension(:    ), allocatable          :: mask_grid_dp_vec_partial
     real(dp), dimension(self%mesh%vi1:self%mesh%vi2) :: mask_dp_dist
+    integer                                          :: vi
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -220,7 +219,7 @@ contains
 
     call open_existing_netcdf_file_for_reading( self%filename, ncid)
     call inquire_var( self%filename, ncid, 'mask', id_var)
-    call read_var_primary( self%filename, ncid, id_var, mask_grid_tot_with_time)
+    call read_var_primary( self%filename, ncid, id_var, mask_grid_tot_with_time, start = [1,1,ti], count = [self%grid_raw%nx, self%grid_raw%ny, 1])
     if (par%primary) mask_grid_dp_tot = real( mask_grid_tot_with_time( :,:,1), dp)
     deallocate( mask_grid_tot_with_time)
     call close_netcdf_file( ncid)
@@ -233,6 +232,11 @@ contains
     ! Remap data to mesh
     call apply_map_xy_grid_to_mesh_2D( self%grid_raw, self%mesh, self%map, mask_grid_dp_vec_partial, mask_dp_dist)
     call dist_to_hybrid( self%mesh%pai_V, mask_dp_dist, mask_dp)
+
+    ! Limit mask values to [0,1]
+    do vi = self%mesh%vi1, self%mesh%vi2
+      mask_dp( vi) = max( 0._dp, min( 1._dp, mask_dp( vi)))
+    end do
 
     ! Finalise routine path
     call finalise_routine( routine_name)

--- a/src/UFEMISM/ISMIP7_forcing/ISMIP7_fracture.f90
+++ b/src/UFEMISM/ISMIP7_forcing/ISMIP7_fracture.f90
@@ -184,6 +184,8 @@ contains
         ! Hydrofracturing can only occur on shelves
 
         ! Interpolate timeframes in time to find the maximum allowed ice fraction
+        ! Note that the provided mask is true (or actually 1) when hydrofracturing
+        ! occurs, so the ice fraction is the inverse of that mask.
         self%max_ice_fraction( vi) = 1._dp - (wt0 * self%mask_dp_t0( vi) + wt1 * self%mask_dp_t1( vi))
 
         ! Calculate maximum allowed ice thickness
@@ -303,7 +305,12 @@ contains
 
     call open_existing_netcdf_file_for_reading( self%filename, ncid)
     call inquire_var( self%filename, ncid, 'mask', id_var)
+
+    ! Read the raw mask data, which is supposed to be a logical, but since NetCDF doesn't support that,
+    ! is read as an 8-bit (half-precision) integer, which only has values 0 and 1.
     call read_var_primary( self%filename, ncid, id_var, mask_grid_tot_with_time, start = [1,1,ti], count = [self%grid_raw%nx, self%grid_raw%ny, 1])
+    ! Convert to floating point, so we can interpolate it to the mesh. The interpolated field
+    ! essentially represents 'which fraction of each Voronoi cell overlaps with grid cells of value 1'.
     if (par%primary) mask_grid_dp_tot = real( mask_grid_tot_with_time( :,:,1), dp)
     deallocate( mask_grid_tot_with_time)
     call close_netcdf_file( ncid)

--- a/src/UFEMISM/ISMIP7_forcing/ISMIP7_fracture.f90
+++ b/src/UFEMISM/ISMIP7_forcing/ISMIP7_fracture.f90
@@ -25,6 +25,7 @@ module ISMIP7_fracture
   use mpi_basic, only: par
   use mpi_distributed_memory_grid, only: distribute_gridded_data_from_primary
   use dist_to_hybrid_mod, only: dist_to_hybrid
+  use ice_geometry_model_data, only: atype_ice_geometry_model_data
 
   implicit none
 
@@ -35,21 +36,27 @@ module ISMIP7_fracture
   type, extends(atype_model) :: type_ISMIP7_fracture_model
 
       character(len=:), allocatable               :: filename
-      real(dp), dimension(:), allocatable         :: time_in_file              ! List of timeframes in the NetCDF file
+      real(dp), dimension(:), allocatable         :: time_in_file                    !       List of timeframes in the NetCDF file
 
-      type(type_grid)                             :: grid_raw                  ! The x/y-grid that the ISMIP7 folks provided the data on
-      type(type_map)                              :: map                       ! Mapping object to remap data from the ISMIP7 grid to the UFEMISM mesh
+      type(type_grid)                             :: grid_raw                        !       The x/y-grid that the ISMIP7 folks provided the data on
+      type(type_map)                              :: map                             !       Mapping object to remap data from the ISMIP7 grid to the UFEMISM mesh
 
-      real(dp)                                    :: t0, t1                    ! Timestamps of enveloping timeframes
-      real(dp), dimension(:), contiguous, pointer :: mask_dp_t0   => null()    ! Left  enveloping timeframe
-      real(dp), dimension(:), contiguous, pointer :: mask_dp_t1   => null()    ! Right enveloping timeframe
+      real(dp)                                    :: t0, t1                          !       Timestamps of enveloping timeframes
+      real(dp), dimension(:), contiguous, pointer :: mask_dp_t0         => null()    ! [0-1] Left  enveloping timeframe
+      real(dp), dimension(:), contiguous, pointer :: mask_dp_t1         => null()    ! [0-1] Right enveloping timeframe
       type(MPI_WIN) :: wmask_dp_t0, wmask_dp_t1
+
+      real(dp), dimension(:), contiguous, pointer :: max_ice_fraction   => null()    ! [0-1] Maximum allowed ice-covered fraction
+      real(dp), dimension(:), contiguous, pointer :: Hi_max             => null()    ! [m]   Maximum allowed ice thickness
+      real(dp), dimension(:), contiguous, pointer :: dHi_calved         => null()    ! [m]   Ice thickness lost to calving
+      type(MPI_WIN) :: wmax_ice_fraction, wHi_max, wdHi_calved
 
     contains
 
       procedure, public :: get_model_name
       procedure, public :: allocate   => ISMIP7_fracture_model_allocate
       procedure, public :: initialise => ISMIP7_fracture_model_initialise
+      procedure, public :: run        => ISMIP7_fracture_model_run
 
       procedure, private :: initialise_remapping_object
       procedure, private :: update_timeframes
@@ -90,6 +97,27 @@ contains
       units     = '0-1', &
       remap_method = 'reallocate')
 
+    call self%create_field( self%max_ice_fraction, self%wmax_ice_fraction, &
+      self%mesh, Arakawa_grid%a(), &
+      name      = 'max_ice_fraction', &
+      long_name = 'Maximum allowed ice-covered fraction', &
+      units     = '0-1', &
+      remap_method = 'reallocate')
+
+    call self%create_field( self%Hi_max, self%wHi_max, &
+      self%mesh, Arakawa_grid%a(), &
+      name      = 'Hi_max', &
+      long_name = 'Maximum allowed ice thickness', &
+      units     = 'm', &
+      remap_method = 'reallocate')
+
+    call self%create_field( self%dHi_calved, self%wdHi_calved, &
+      self%mesh, Arakawa_grid%a(), &
+      name      = 'dHi_calved', &
+      long_name = 'Ice thickness lost to calving', &
+      units     = 'm', &
+      remap_method = 'reallocate')
+
     ! Remove routine from call stack
     call finalise_routine( routine_name)
 
@@ -101,7 +129,7 @@ contains
     class(type_ISMIP7_fracture_model), intent(inout) :: self
 
     ! Local variables:
-    character(len=*), parameter   :: routine_name = 'ISMIP7_fracture_model_initialise'
+    character(len=*), parameter :: routine_name = 'ISMIP7_fracture_model_initialise'
 
     ! Add routine to call stack
     call init_routine( routine_name)
@@ -119,12 +147,68 @@ contains
     self%t1 = C%start_time_of_run - 1._dp
     call self%update_timeframes( C%start_time_of_run)
 
-    call crash('whoopsiedaisy')
-
     ! Remove routine from call stack
     call finalise_routine( routine_name)
 
   end subroutine ISMIP7_fracture_model_initialise
+
+  subroutine ISMIP7_fracture_model_run( self, time, geom, Hi)
+
+    ! In/output variables:
+    class(type_ISMIP7_fracture_model),                                  intent(inout) :: self
+    real(dp),                                                           intent(in   ) :: time
+    class(atype_ice_geometry_model_data),                               intent(in   ) :: geom
+    real(dp), dimension(self%mesh%vi1:self%mesh%vi2), intent(inout) :: Hi
+    ! real(dp), dimension(self%mesh%pai_V%i1_nih:self%mesh%pai_V%i2_nih), intent(inout) :: Hi
+
+    ! Local variables:
+    character(len=*), parameter :: routine_name = 'ISMIP7_fracture_model_run'
+    real(dp)                    :: wt0, wt1
+    integer                     :: vi
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    if (time < self%t0 .or. time > self%t1) then
+      call self%update_timeframes( time)
+    end if
+
+    ! Calculate time interpolation weights
+    wt0 = (self%t1 - time) / (self%t1 - self%t0)
+    wt0 = max( 0._dp, min( 1._dp, wt0 ))
+    wt1 = 1._dp - wt0
+
+    do vi = self%mesh%vi1, self%mesh%vi2
+
+      if (.not. geom%mask_grounded_ice( vi)) then
+        ! Hydrofracturing can only occur on shelves
+
+        ! Interpolate timeframes in time to find the maximum allowed ice fraction
+        self%max_ice_fraction( vi) = 1._dp - (wt0 * self%mask_dp_t0( vi) + wt1 * self%mask_dp_t1( vi))
+
+        ! Calculate maximum allowed ice thickness
+        self%Hi_max( vi) = geom%Hi_eff( vi) * self%max_ice_fraction( vi)
+
+        ! Apply maximum allowed ice thickness
+        if (Hi( vi) > self%Hi_max( vi)) then
+          self%dHi_calved( vi) = Hi( vi) - self%Hi_max( vi)
+          Hi( vi) = self%Hi_max( vi)
+        else
+          self%dHi_calved( vi) = 0._dp
+        end if
+
+      else
+        self%max_ice_fraction( vi) = 1._dp
+        self%Hi_max          ( vi) = Hi( vi)
+        self%dHi_calved      ( vi) = 0._dp
+      end if
+
+    end do
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine ISMIP7_fracture_model_run
 
   subroutine initialise_remapping_object( self)
 

--- a/src/UFEMISM/ice_dynamics/ice_dynamics_main.f90
+++ b/src/UFEMISM/ice_dynamics/ice_dynamics_main.f90
@@ -396,6 +396,11 @@ contains
     ice%n_visc_its = 0
     ice%n_Axb_its  = 0
 
+    ! ISMIP7 mask-based hydrofracture model
+    if (C%do_apply_ISMIP7_fracture_mask) then
+      call ice%ISMIP7_fracture%initialise()
+    end if
+
     ! Finalise routine path
     call finalise_routine( routine_name)
 

--- a/src/UFEMISM/ice_dynamics/ice_model_main.f90
+++ b/src/UFEMISM/ice_dynamics/ice_model_main.f90
@@ -4,6 +4,7 @@ module ice_model_main
   use ice_geometry_model_basic, only: type_ice_geometry_model
   use ice_velocity_model_basic, only: atype_ice_velocity_model
   use momentum_balance_solver_basic, only: atype_momentum_balance_solver
+  use ISMIP7_fracture, only: type_ISMIP7_fracture_model
 
   implicit none
 
@@ -16,6 +17,7 @@ module ice_model_main
       class(type_ice_geometry_model),       allocatable :: geom                      !< Ice-sheet geometry
       class(atype_ice_velocity_model),      allocatable :: vel                       !< Ice-sheet velocity
       class(atype_momentum_balance_solver), allocatable :: momentum_balance_solver   !< The momentum balance solver
+      class(type_ISMIP7_fracture_model),    allocatable :: ISMIP7_fracture           !< The ISMIP7 mask-based hydrofracture model
 
     contains
 

--- a/src/UFEMISM/ice_dynamics/time_stepping/predictor_corrector_scheme.f90
+++ b/src/UFEMISM/ice_dynamics/time_stepping/predictor_corrector_scheme.f90
@@ -94,6 +94,9 @@ contains
           beta_2 * region%ice%pc%dHi_dt_Hi_nm1_u_nm1( vi))
       end do
       call apply_noice_mask( region%mesh, region%ice%mask_noice, region%ice%pc%Hi_star_np1)
+      if (C%do_apply_ISMIP7_fracture_mask) then
+        call region%ice%ISMIP7_fracture%run( region%time, region%ice%geom, region%ice%pc%Hi_star_np1)
+      end if
       call forbid_negative_ice_thickness( region%mesh, region%ice%pc%Hi_star_np1)
       call remove_unconnected_shelves( region%mesh, region%ice%geom%Hb, region%ice%geom%SL, region%ice%pc%Hi_star_np1)
       call alter_ice_thickness( region%mesh, region%ice, region%ice%geom, region%ice%Hi_prev, &
@@ -135,6 +138,9 @@ contains
       region%ice%pc%Hi_np1 = region%ice%Hi_prev + (region%ice%pc%dt_np1 / 2._dp) * &
         (region%ice%pc%dHi_dt_Hi_n_u_n + region%ice%pc%dHi_dt_Hi_star_np1_u_np1)
       call apply_noice_mask( region%mesh, region%ice%mask_noice, region%ice%pc%Hi_np1)
+      if (C%do_apply_ISMIP7_fracture_mask) then
+        call region%ice%ISMIP7_fracture%run( region%time, region%ice%geom, region%ice%pc%Hi_np1)
+      end if
       call forbid_negative_ice_thickness( region%mesh, region%ice%pc%Hi_np1)
       call remove_unconnected_shelves( region%mesh, region%ice%geom%Hb, region%ice%geom%SL, region%ice%pc%Hi_np1)
       call alter_ice_thickness( region%mesh, region%ice, region%ice%geom, region%ice%Hi_prev, &

--- a/src/UFEMISM/ice_dynamics/utilities/ice_model_memory.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_model_memory.f90
@@ -38,6 +38,11 @@ contains
     call create_momentum_balance_solver( ice%momentum_balance_solver, C%choice_stress_balance_approximation)
     call ice%momentum_balance_solver%allocate( region_name, mesh)
 
+    if (C%do_apply_ISMIP7_fracture_mask) then
+      allocate( ice%ISMIP7_fracture)
+      call ice%ISMIP7_fracture%allocate( region_name, mesh)
+    end if
+
     ! Geometry changes
     allocate( ice%dHi ( mesh%vi1:mesh%vi2), source = 0._dp)
     allocate( ice%dHb ( mesh%vi1:mesh%vi2), source = 0._dp)

--- a/src/UPSY/basic/model_configuration/model_configuration_type_and_namelist.f90
+++ b/src/UPSY/basic/model_configuration/model_configuration_type_and_namelist.f90
@@ -434,6 +434,9 @@ module model_configuration_type_and_namelist
     logical             :: continental_shelf_calving_config             = .false.                          ! If set to TRUE, all ice beyond the continental shelf edge (set by a maximum depth) is removed
     real(dp)            :: continental_shelf_min_height_config          = -2000._dp                        ! Maximum depth of the continental shelf
 
+    logical             :: do_apply_ISMIP7_fracture_mask_config         = .false.                          ! Whether or not to apply the ISMIP7 mask-based hydrofracturing forcing
+    character(len=1024) :: filename_ISMIP7_fracture_mask_config         = ''                               ! The full path to the NetCDF file containing the ISMIP7 hydrofracturing mask
+
   ! == Ice dynamics - stabilisation
   ! ===============================
 
@@ -489,7 +492,7 @@ module model_configuration_type_and_namelist
     real(dp)            :: Salle2025_hydro_meltwater_config             = 2.186523556E-7_dp                ! [kg m^-2 s^-1] of meltwater added to basal hydrology system
     real(dp)            :: Salle2025_W_til_max_config                   = 2.0_dp                           ! [m] Maximum allowed till water layer thickness
     real(dp)            :: Salle2025_initial_W_til_config               = 2.0_dp                           ! [m] Initial till water layer thickness
-    real(dp)            :: Salle2025_initial_W_config                   = 0.01_dp                          ! [m] Initial subglacial water layer thickness 
+    real(dp)            :: Salle2025_initial_W_config                   = 0.01_dp                          ! [m] Initial subglacial water layer thickness
     real(dp)            :: Salle2025_Cd_config                          = 3.168874718E-11_dp               ! [m s^-1] Water leaking back from the till to the water layer above
     real(dp)            :: Salle2025_phi_config                         = 26.565_dp                        ! [degrees] till yield stress angle
 
@@ -1691,6 +1694,9 @@ module model_configuration_type_and_namelist
     logical             :: continental_shelf_calving
     real(dp)            :: continental_shelf_min_height
 
+    logical             :: do_apply_ISMIP7_fracture_mask
+    character(len=1024) :: filename_ISMIP7_fracture_mask
+
   ! == Ice dynamics - stabilisation
   ! ===============================
 
@@ -2833,6 +2839,8 @@ contains
       remove_shelves_larger_than_PD_config                        , &
       continental_shelf_calving_config                            , &
       continental_shelf_min_height_config                         , &
+      do_apply_ISMIP7_fracture_mask_config                        , &
+      filename_ISMIP7_fracture_mask_config                        , &
       choice_mask_noice_config                                    , &
       Hi_min_config                                               , &
       Hi_thin_config                                              , &
@@ -2867,7 +2875,7 @@ contains
       error_function_max_effective_pressure_config                , &
       Leguy2014_hydro_connect_exponent_config                     , &
       Salle2025_hydro_meltwater_config                            , &
-      Salle2025_W_til_max_config                                  , & 
+      Salle2025_W_til_max_config                                  , &
       Salle2025_initial_W_til_config                              , &
       Salle2025_initial_W_config                                  , &
       Salle2025_Cd_config                                         , &
@@ -3841,6 +3849,9 @@ contains
     C%continental_shelf_calving                              = continental_shelf_calving_config
     C%continental_shelf_min_height                           = continental_shelf_min_height_config
 
+    C%do_apply_ISMIP7_fracture_mask                          = do_apply_ISMIP7_fracture_mask_config
+    C%filename_ISMIP7_fracture_mask                          = filename_ISMIP7_fracture_mask_config
+
     ! == Ice dynamics - stabilisation
     ! ===============================
 
@@ -4426,12 +4437,12 @@ contains
 
     ! Initialisation
     C%choice_laddie_model_initialisation                     = choice_laddie_model_initialisation_config
- 
-    ! Initialisation 'read_from_file' 
+
+    ! Initialisation 'read_from_file'
     C%filename_laddie_restart                                = filename_laddie_restart_config
     C%timeframe_laddie_restart                               = timeframe_laddie_restart_config
- 
-    ! Initialisation 'uniform' 
+
+    ! Initialisation 'uniform'
     C%laddie_initial_thickness                               = laddie_initial_thickness_config
     C%laddie_initial_T_offset                                = laddie_initial_T_offset_config
     C%laddie_initial_S_offset                                = laddie_initial_S_offset_config

--- a/src/UPSY/io/netcdf_basic/netcdf_read_var_primary.f90
+++ b/src/UPSY/io/netcdf_basic/netcdf_read_var_primary.f90
@@ -7,7 +7,8 @@ module netcdf_read_var_primary
   use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine, crash
   use netcdf_field_name_options
   use netcdf_basic_wrappers
-  use netcdf, only: NF90_MAX_VAR_DIMS, NF90_DOUBLE, NF90_FLOAT, NF90_INT, NF90_INT64, NF90_GET_VAR
+  use netcdf, only: NF90_MAX_VAR_DIMS, NF90_DOUBLE, NF90_FLOAT, NF90_INT, NF90_INT64, NF90_GET_VAR, &
+    NF90_BYTE
 
   implicit none
 
@@ -69,8 +70,8 @@ subroutine read_var_primary_logical_0D(  filename, ncid, id_var, d)
   call inquire_var_info( filename, ncid, id_var, var_name = var_name, var_type = var_type, ndims_of_var = ndims_of_var)
 
   ! Check variable type
-  if (.not. (var_type == NF90_INT)) &
-    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT!')
+  if (.not. (var_type == NF90_INT .or. var_type == NF90_BYTE)) &
+    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT or NF90_BYTE!')
 
   ! Check number of dimensions
   if (ndims_of_var /= 0) call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" has {int_01} dimensions!', int_01 = ndims_of_var)
@@ -119,8 +120,8 @@ subroutine read_var_primary_logical_1D( filename, ncid, id_var, d, start, count)
   call inquire_var_info( filename, ncid, id_var, var_name = var_name, var_type = var_type, ndims_of_var = ndims_of_var, dims_of_var = dims_of_var)
 
   ! Check variable type
-  if (.not. (var_type == NF90_INT)) &
-    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT!')
+  if (.not. (var_type == NF90_INT .or. var_type == NF90_BYTE)) &
+    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT or NF90_BYTE!')
 
   ! Check number of dimensions
   if (ndims_of_var /= 1) call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" has {int_01} dimensions!', int_01 = ndims_of_var)
@@ -204,8 +205,8 @@ subroutine read_var_primary_logical_2D( filename, ncid, id_var, d, start, count)
   call inquire_var_info( filename, ncid, id_var, var_name = var_name, var_type = var_type, ndims_of_var = ndims_of_var, dims_of_var = dims_of_var)
 
   ! Check variable type
-  if (.not. (var_type == NF90_INT)) &
-    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT!')
+  if (.not. (var_type == NF90_INT .or. var_type == NF90_BYTE)) &
+    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT or NF90_BYTE!')
 
   ! Check number of dimensions
   if (ndims_of_var /= 2) call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" has {int_01} dimensions!', int_01 = ndims_of_var)
@@ -289,8 +290,8 @@ subroutine read_var_primary_logical_3D( filename, ncid, id_var, d, start, count)
   call inquire_var_info( filename, ncid, id_var, var_name = var_name, var_type = var_type, ndims_of_var = ndims_of_var, dims_of_var = dims_of_var)
 
   ! Check variable type
-  if (.not. (var_type == NF90_INT)) &
-    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT!')
+  if (.not. (var_type == NF90_INT .or. var_type == NF90_BYTE)) &
+    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT or NF90_BYTE!')
 
   ! Check number of dimensions
   if (ndims_of_var /= 3) call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" has {int_01} dimensions!', int_01 = ndims_of_var)
@@ -374,8 +375,8 @@ subroutine read_var_primary_logical_4D( filename, ncid, id_var, d, start, count)
   call inquire_var_info( filename, ncid, id_var, var_name = var_name, var_type = var_type, ndims_of_var = ndims_of_var, dims_of_var = dims_of_var)
 
   ! Check variable type
-  if (.not. (var_type == NF90_INT)) &
-    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT!')
+  if (.not. (var_type == NF90_INT .or. var_type == NF90_BYTE)) &
+    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT or NF90_BYTE!')
 
   ! Check number of dimensions
   if (ndims_of_var /= 4) call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" has {int_01} dimensions!', int_01 = ndims_of_var)
@@ -455,8 +456,8 @@ subroutine read_var_primary_int_0D(  filename, ncid, id_var, d)
   call inquire_var_info( filename, ncid, id_var, var_name = var_name, var_type = var_type, ndims_of_var = ndims_of_var)
 
   ! Check variable type
-  if (.not. (var_type == NF90_INT)) &
-    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT!')
+  if (.not. (var_type == NF90_INT .or. var_type == NF90_BYTE)) &
+    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT or NF90_BYTE!')
 
   ! Check number of dimensions
   if (ndims_of_var /= 0) call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" has {int_01} dimensions!', int_01 = ndims_of_var)
@@ -503,8 +504,8 @@ subroutine read_var_primary_int_1D( filename, ncid, id_var, d, start, count)
   call inquire_var_info( filename, ncid, id_var, var_name = var_name, var_type = var_type, ndims_of_var = ndims_of_var, dims_of_var = dims_of_var)
 
   ! Check variable type
-  if (.not. (var_type == NF90_INT)) &
-    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT!')
+  if (.not. (var_type == NF90_INT .or. var_type == NF90_BYTE)) &
+    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT or NF90_BYTE!')
 
   ! Check number of dimensions
   if (ndims_of_var /= 1) call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" has {int_01} dimensions!', int_01 = ndims_of_var)
@@ -586,8 +587,8 @@ subroutine read_var_primary_int_2D( filename, ncid, id_var, d, start, count)
   call inquire_var_info( filename, ncid, id_var, var_name = var_name, var_type = var_type, ndims_of_var = ndims_of_var, dims_of_var = dims_of_var)
 
   ! Check variable type
-  if (.not. (var_type == NF90_INT)) &
-    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT!')
+  if (.not. (var_type == NF90_INT .or. var_type == NF90_BYTE)) &
+    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT or NF90_BYTE!')
 
   ! Check number of dimensions
   if (ndims_of_var /= 2) call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" has {int_01} dimensions!', int_01 = ndims_of_var)
@@ -669,8 +670,8 @@ subroutine read_var_primary_int_3D( filename, ncid, id_var, d, start, count)
   call inquire_var_info( filename, ncid, id_var, var_name = var_name, var_type = var_type, ndims_of_var = ndims_of_var, dims_of_var = dims_of_var)
 
   ! Check variable type
-  if (.not. (var_type == NF90_INT)) &
-    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT!')
+  if (.not. (var_type == NF90_INT .or. var_type == NF90_BYTE)) &
+    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT or NF90_BYTE!')
 
   ! Check number of dimensions
   if (ndims_of_var /= 3) call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" has {int_01} dimensions!', int_01 = ndims_of_var)
@@ -752,8 +753,8 @@ subroutine read_var_primary_int_4D( filename, ncid, id_var, d, start, count)
   call inquire_var_info( filename, ncid, id_var, var_name = var_name, var_type = var_type, ndims_of_var = ndims_of_var, dims_of_var = dims_of_var)
 
   ! Check variable type
-  if (.not. (var_type == NF90_INT)) &
-    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT!')
+  if (.not. (var_type == NF90_INT .or. var_type == NF90_BYTE)) &
+    call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" is not of type NF90_INT or NF90_BYTE!')
 
   ! Check number of dimensions
   if (ndims_of_var /= 4) call crash('variable "' // trim( var_name) // '" in file "' // trim( filename) // '" has {int_01} dimensions!', int_01 = ndims_of_var)
@@ -804,8 +805,8 @@ subroutine read_var_primary_int_4D( filename, ncid, id_var, d, start, count)
 
 end subroutine read_var_primary_int_4D
 
-! ===== integer =====
-! ===================
+! ===== 64-bit/8-byte integer =====
+! =================================
 
 subroutine read_var_primary_int64_0D(  filename, ncid, id_var, d)
   ! Read data from a NetCDF file


### PR DESCRIPTION
Add the ISMIP7 mask-based hydrofracture forcing. As with the climate and SMB forcing, it only stores two timeframes enveloping the model time in memory, and only updates those timeframes when necessary, using a pre-computed mapping operator for maximum efficiency.

ISMIP7 provides a mask for every year, indicating where hydrofracturing should occur if shelves are present. The file's time dimension is integer-valued and in units of years, because why be consistent. The mask itself is a 8-bit integer, which UFEMISM now supports. The two timeframes are read as integer, converted to floating-point, and interpolated to the mesh using 1st-order conservative remapping to ensure that the remapped values remain within the 0-1 range. The resulting field effectively represents the 'maximum ice-filled fraction' of each Voronoi cell, and this is also exactly how they are implemented in the p/c-scheme. Both the predicted and corrected ice thickness are treated; the maximum ice-filled fraction is calculated from the forcing file, and, from the known effective ice thickness, the maximum allowed ice thickness is calculated. Any ice exceeding this thickness is removed. The removed ice is tracked, so it can eventually be accounted for when calculating the calving flux (this is currently not done!).

Ran a short test locally to confirm that the shelves retreat in the expected fashion.

Note that for some experiments, ISMIP7 provides the fracture forcing data as v1 and v2, while for others it is v2 and v2.1