### PR TITLE
Add PETSc dmplex test code

### DIFF
--- a/.github/workflows/UPSY_test_suite.yml
+++ b/.github/workflows/UPSY_test_suite.yml
@@ -18,6 +18,18 @@ jobs:
   unit_tests:
     uses: ./.github/workflows/UPSY_test_suite_unit_tests.yml
 
+  PETSc_matrix_solving:
+    uses: ./.github/workflows/UPSY_test_suite_run_and_check_test.yml
+    with:
+      test_path: automated_testing/UPSY/component_test_PETSc_matrix_solving
+      compile_script: compile_UPSY.csh
+
+  PETSc_DMPLEX:
+    uses: ./.github/workflows/UPSY_test_suite_run_and_check_test.yml
+    with:
+      test_path: automated_testing/UPSY/component_test_PETSc_DMPLEX
+      compile_script: compile_UPSY.csh
+
   mesh_creation:
     uses: ./.github/workflows/UPSY_test_suite_run_and_check_test.yml
     with:

--- a/.github/workflows/UPSY_test_suite_run_and_check_test.yml
+++ b/.github/workflows/UPSY_test_suite_run_and_check_test.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       runner: ${{ steps.select.outputs.runner }}
       reference_dir: ${{ steps.select.outputs.reference_dir }}
+      has_reference: ${{ steps.select.outputs.has_reference }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -54,6 +55,7 @@ jobs:
 
           runner=""
           reference_dir=""
+          has_reference="true"
 
           if [[ "$ts_linux" -gt 0 && "$ts_macos" -gt 0 ]]; then
             if [[ "$ts_linux" -ge "$ts_macos" ]]; then
@@ -70,15 +72,19 @@ jobs:
             runner="macos-latest"
             reference_dir="reference_macos"
           else
-            echo "ERROR: Could not find reference_linux or reference_macos in $test_path"
-            exit 1
+            echo "No reference folder found; defaulting to macOS"
+            runner="macos-latest"
+            reference_dir="reference_macos"
+            has_reference="false"
           fi
 
           echo "Selected reference folder: $reference_dir"
           echo "Selected runner: $runner"
+          echo "Reference available: $has_reference"
 
           echo "runner=$runner" >> "$GITHUB_OUTPUT"
           echo "reference_dir=$reference_dir" >> "$GITHUB_OUTPUT"
+          echo "has_reference=$has_reference" >> "$GITHUB_OUTPUT"
 
   run_and_check_test:
     name: run
@@ -130,10 +136,12 @@ jobs:
         run: csh ${{ inputs.test_path }}/test_script.csh
 
       - name: Show checksum logfile diff
+        if: needs.select_reference.outputs.has_reference == 'true'
         shell: micromamba-shell {0}
         run: csh automated_testing/show_checksum_logfile_diff.csh  ${{ inputs.test_path }}  ${{ needs.select_reference.outputs.reference_dir }}
 
       - name: Check test result
+        if: needs.select_reference.outputs.has_reference == 'true'
         shell: micromamba-shell {0}
         run: |
           python automated_testing/compare_program_info.py                ${{ github.workspace }}/${{ inputs.test_path }}  ${{ needs.select_reference.outputs.reference_dir }}

--- a/automated_testing/UPSY/component_test_PETSc_DMPLEX/test_script.csh
+++ b/automated_testing/UPSY/component_test_PETSc_DMPLEX/test_script.csh
@@ -1,0 +1,9 @@
+#! /bin/csh -f
+
+set test_dir = automated_testing/UPSY/component_test_PETSc_DMPLEX
+
+rm -rf ${test_dir}/results*
+
+mpiexec  -n 2  build/src/UPSY/UPSY_component_test_program_PETSc_DMPLEX  ${test_dir}/results  automated_testing/UPSY/component_test_PETSc_DMPLEX/test_matrix_equations
+
+python3 automated_testing/reduce_all_netcdfs_in_folder_to_checksum.py ${test_dir}

--- a/automated_testing/UPSY/component_test_PETSc_DMPLEX/visualise_DMPLEX.py
+++ b/automated_testing/UPSY/component_test_PETSc_DMPLEX/visualise_DMPLEX.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Visualise a two-dimensional PETSc DMPlex saved in an HDF5 file."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import h5py
+import matplotlib.pyplot as plt
+from matplotlib.collections import PolyCollection
+import numpy as np
+
+
+DEFAULT_FILENAME = Path(__file__).parent / "results" / "PETSc_DMPLEX_output.h5"
+
+
+class DMPlexFormatError(ValueError):
+    """Raised when a file does not use the expected PETSc DMPlex layout."""
+
+
+def calculate_point_depths(point_cones: dict[int, list[int]]) -> dict[int, int]:
+    """Return the DAG depth of each DMPlex point."""
+
+    point_depths: dict[int, int] = {}
+
+    def point_depth(point: int, ancestors: set[int]) -> int:
+        if point in point_depths:
+            return point_depths[point]
+        if point in ancestors:
+            raise DMPlexFormatError("the DMPlex topology contains a cycle")
+        if point not in point_cones:
+            raise DMPlexFormatError(f"point {point} is missing from /topology/order")
+
+        cone = point_cones[point]
+        if not cone:
+            point_depths[point] = 0
+        else:
+            point_depths[point] = 1 + max(point_depth(child, ancestors | {point}) for child in cone)
+        return point_depths[point]
+
+    for point in point_cones:
+        point_depth(point, set())
+
+    return point_depths
+
+
+def order_boundary_edges(edges: list[list[int]]) -> list[int]:
+    """Order a closed sequence of two-vertex edges into a cell boundary."""
+
+    if not edges or any(len(edge) != 2 for edge in edges):
+        raise DMPlexFormatError("a two-dimensional cell must be bounded by two-vertex edges")
+
+    polygon = [edges[0][0], edges[0][1]]
+    unused_edges = edges[1:]
+
+    while unused_edges:
+        current_vertex = polygon[-1]
+        matching_edges = [edge for edge in unused_edges if current_vertex in edge]
+        if len(matching_edges) != 1:
+            raise DMPlexFormatError("could not order the boundary edges of a cell")
+
+        edge = matching_edges[0]
+        unused_edges.remove(edge)
+        next_vertex = edge[1] if edge[0] == current_vertex else edge[0]
+
+        if not unused_edges:
+            if next_vertex != polygon[0]:
+                raise DMPlexFormatError("the boundary edges of a cell do not form a closed polygon")
+        elif next_vertex == polygon[0]:
+            raise DMPlexFormatError("the boundary edges close before all cell edges are used")
+        else:
+            polygon.append(next_vertex)
+
+    return polygon
+
+
+def extract_cell_vertices(
+    cell: int,
+    point_cones: dict[int, list[int]],
+    point_depths: dict[int, int],
+) -> list[int]:
+    """Return the ordered vertex point IDs on a two-dimensional cell boundary."""
+
+    cone = point_cones[cell]
+    cone_depths = [point_depths[point] for point in cone]
+
+    if all(depth == 0 for depth in cone_depths):
+        return cone
+    if all(depth == 1 for depth in cone_depths):
+        return order_boundary_edges([point_cones[edge] for edge in cone])
+
+    raise DMPlexFormatError(f"cell point {cell} has an unsupported mixed-depth cone")
+
+
+def load_dmplex_mesh(filename: Path) -> tuple[list[np.ndarray], dict[int, np.ndarray]]:
+    """Read vertices and two-dimensional cell boundaries from a PETSc DMPlex file."""
+
+    try:
+        with h5py.File(filename, "r") as h5_file:
+            vertices = np.asarray(h5_file["/geometry/vertices"], dtype=float)
+            cells_dataset = h5_file["/topology/cells"]
+            cell_values = np.asarray(cells_dataset, dtype=int).ravel()
+            cone_sizes = np.asarray(h5_file["/topology/cones"], dtype=int).ravel()
+            point_ids = np.asarray(h5_file["/topology/order"], dtype=int).ravel()
+            cell_dimension = int(cells_dataset.attrs["cell_dim"])
+    except KeyError as exception:
+        raise DMPlexFormatError(f"missing PETSc DMPlex dataset: {exception}") from exception
+
+    if cell_dimension != 2:
+        raise DMPlexFormatError(f"only two-dimensional DMPlex files are supported, got dimension {cell_dimension}")
+    if vertices.ndim != 2 or vertices.shape[1] < 2:
+        raise DMPlexFormatError("/geometry/vertices must have at least two coordinate columns")
+    if len(point_ids) != len(cone_sizes):
+        raise DMPlexFormatError("/topology/order and /topology/cones have incompatible lengths")
+    if np.any(cone_sizes < 0) or int(cone_sizes.sum()) != len(cell_values):
+        raise DMPlexFormatError("/topology/cones does not describe /topology/cells")
+    if len(np.unique(point_ids)) != len(point_ids):
+        raise DMPlexFormatError("/topology/order contains duplicate point IDs")
+
+    point_cones: dict[int, list[int]] = {}
+    offset = 0
+    for point, cone_size in zip(point_ids, cone_sizes, strict=True):
+        point_cones[int(point)] = [int(child) for child in cell_values[offset : offset + cone_size]]
+        offset += cone_size
+
+    point_depths = calculate_point_depths(point_cones)
+    vertex_ids = [point for point in point_ids if point_depths[int(point)] == 0]
+    if len(vertex_ids) != len(vertices):
+        raise DMPlexFormatError(
+            "/geometry/vertices does not contain one coordinate row for each zero-depth DMPlex point"
+        )
+
+    vertex_coordinates = {
+        int(point): coordinates[:2] for point, coordinates in zip(vertex_ids, vertices, strict=True)
+    }
+    cell_ids = [point for point in point_ids if point_depths[int(point)] == cell_dimension]
+    polygons = [
+        np.asarray([vertex_coordinates[point] for point in extract_cell_vertices(int(cell), point_cones, point_depths)])
+        for cell in cell_ids
+    ]
+
+    return polygons, vertex_coordinates
+
+
+def deduplicate_polygons(polygons: list[np.ndarray]) -> list[np.ndarray]:
+    """Remove geometrically identical cells written by replicated MPI ranks."""
+
+    unique_polygons: list[np.ndarray] = []
+    polygon_keys: set[tuple[tuple[float, float], ...]] = set()
+    for polygon in polygons:
+        key = tuple(sorted(tuple(float(value) for value in vertex) for vertex in polygon))
+        if key not in polygon_keys:
+            polygon_keys.add(key)
+            unique_polygons.append(polygon)
+
+    return unique_polygons
+
+
+def plot_dmplex_mesh(
+    polygons: list[np.ndarray], vertex_coordinates: dict[int, np.ndarray], point_labels: bool
+) -> plt.Figure:
+    """Create a matplotlib figure for a DMPlex mesh."""
+
+    figure, axis = plt.subplots(figsize=(7, 7), constrained_layout=True)
+    unique_polygons = deduplicate_polygons(polygons)
+    axis.add_collection(
+        PolyCollection(
+            unique_polygons,
+            facecolors="#d8ecef",
+            edgecolors="#145a6b",
+            linewidths=1.5,
+        )
+    )
+
+    coordinates = np.asarray(list(vertex_coordinates.values()))
+    unique_coordinates = np.unique(coordinates, axis=0)
+    axis.scatter(
+        unique_coordinates[:, 0],
+        unique_coordinates[:, 1],
+        color="#d1495b",
+        edgecolor="#6d1f2a",
+        linewidth=0.5,
+        s=35,
+        zorder=2,
+    )
+
+    if point_labels:
+        for point, coordinates in vertex_coordinates.items():
+            axis.annotate(str(point), coordinates, xytext=(5, 5), textcoords="offset points")
+
+    axis.autoscale_view()
+    axis.margins(0.1)
+    axis.set_aspect("equal", adjustable="box")
+    axis.set_xlabel("x")
+    axis.set_ylabel("y")
+    axis.set_title(f"PETSc DMPlex: {len(unique_polygons)} cells, {len(unique_coordinates)} vertices")
+
+    return figure
+
+
+def main() -> None:
+    """Parse command-line arguments and display or save the mesh figure."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "filename",
+        nargs="?",
+        type=Path,
+        default=DEFAULT_FILENAME,
+        help=f"PETSc DMPlex HDF5 file (default: {DEFAULT_FILENAME})",
+    )
+    parser.add_argument("-o", "--output", type=Path, help="write the figure to this file instead of displaying it")
+    parser.add_argument("--point-labels", action="store_true", help="label vertices with their DMPlex point IDs")
+    arguments = parser.parse_args()
+
+    try:
+        polygons, vertex_coordinates = load_dmplex_mesh(arguments.filename)
+    except (DMPlexFormatError, OSError) as exception:
+        parser.error(str(exception))
+
+    figure = plot_dmplex_mesh(polygons, vertex_coordinates, arguments.point_labels)
+    if arguments.output is None:
+        plt.show()
+    else:
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        figure.savefig(arguments.output, dpi=180)
+        print(f"Wrote {arguments.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/automated_testing/reduce_all_netcdfs_in_folder_to_checksum.py
+++ b/automated_testing/reduce_all_netcdfs_in_folder_to_checksum.py
@@ -12,7 +12,7 @@ Usage:
 Behavior:
 - Reads all *.nc files from <test_folder>/results
 - Excludes *_checksum.nc and resource_tracking.nc
-- Creates <test_folder>/results_checksum if needed
+- Creates <test_folder>/results_checksum only when files are found
 - For each file:
     - Creates results_checksum/<name>_checksum.nc containing:
         - one 3-value stats checksum variable per original variable
@@ -188,11 +188,6 @@ def reduce_all_netcdfs_in_folder_to_checksum(test_folder: str) -> None:
     if not os.path.isdir(results_dir):
         raise FileNotFoundError(f'Could not find results folder "{results_dir}"')
 
-    results_checksum_dir = os.path.join(test_folder, "results_checksum")
-    if os.path.exists(results_checksum_dir):
-        raise FileExistsError(f'Folder already exists: "{results_checksum_dir}"')
-    os.makedirs(results_checksum_dir)
-
     files = sorted(
         name
         for name in os.listdir(results_dir)
@@ -200,6 +195,13 @@ def reduce_all_netcdfs_in_folder_to_checksum(test_folder: str) -> None:
         and not name.endswith("_checksum.nc")
         and name.lower() != "resource_tracking.nc"
     )
+    if not files:
+        return
+
+    results_checksum_dir = os.path.join(test_folder, "results_checksum")
+    if os.path.exists(results_checksum_dir):
+        raise FileExistsError(f'Folder already exists: "{results_checksum_dir}"')
+    os.makedirs(results_checksum_dir)
 
     for i, name in enumerate(files, start=1):
         print(f"Reducing file {i}/{len(files)}: {name}")

--- a/compile_UFEMISM.csh
+++ b/compile_UFEMISM.csh
@@ -67,6 +67,19 @@ if ($selection == 'clean') rm -rf build/*
 # For a "changed" build, remove only the CMake cache file
 if ($selection == 'changed') rm -f build/CMakeCache.txt
 
+# Prefer the PETSc installation from the active conda environment, if available.
+# This keeps the build and runtime environment consistent for the UPSY project.
+set petsc_dir = "$CONDA_PREFIX"
+if ("$petsc_dir" == "") then
+  set petsc_dir = "/Users/Beren017/miniforge3/envs/upsy"
+endif
+
+if (! -d "$petsc_dir") then
+  echo "Error: PETSc environment not found at $petsc_dir"
+  set compile_exit_code = 1
+  goto cleanup
+endif
+
 set compile_exit_code = 0
 set in_build_dir = 0
 
@@ -85,7 +98,7 @@ set in_build_dir = 1
 
 if ($version == 'dev') then
 
-  cmake -G Ninja -DPETSC_DIR=`brew --prefix petsc` \
+  cmake -G Ninja -DPETSC_DIR="$petsc_dir" \
     -DBUILD_UFEMISM=ON \
     -DDO_ASSERTIONS=ON \
     -DDO_RESOURCE_TRACKING=ON \
@@ -93,7 +106,7 @@ if ($version == 'dev') then
 
 else if ($version == 'perf') then
 
-  cmake -G Ninja -DPETSC_DIR=`brew --prefix petsc` \
+  cmake -G Ninja -DPETSC_DIR="$petsc_dir" \
     -DBUILD_UFEMISM=ON \
     -DDO_ASSERTIONS=OFF \
     -DDO_RESOURCE_TRACKING=OFF \

--- a/compile_UPSY.csh
+++ b/compile_UPSY.csh
@@ -73,6 +73,36 @@ if ($selection == 'clean') rm -rf build/*
 # For a "changed" build, remove only the CMake cache file
 if ($selection == 'changed') rm -f build/CMakeCache.txt
 
+# Force the conda environment to be active for this build, so PETSc and MPI come from
+# the same installation and not from a stale Homebrew copy.
+if ($?CONDA_PREFIX == 0) then
+  source /Users/Beren017/miniforge3/etc/profile.d/conda.csh
+  if ($status != 0) then
+    echo "Warning: failed to source conda.csh hook; continuing with the current environment"
+  endif
+endif
+
+if ($?CONDA_PREFIX == 0) then
+  setenv PATH "/Users/Beren017/miniforge3/envs/upsy/bin:$PATH"
+  setenv LD_LIBRARY_PATH "/Users/Beren017/miniforge3/envs/upsy/lib:$LD_LIBRARY_PATH"
+  setenv LIBRARY_PATH "/Users/Beren017/miniforge3/envs/upsy/lib:$LIBRARY_PATH"
+endif
+
+set petsc_dir = "$CONDA_PREFIX"
+if ("$petsc_dir" == "") then
+  set petsc_dir = "/Users/Beren017/miniforge3/envs/upsy"
+endif
+
+if (! -d "$petsc_dir") then
+  echo "Error: PETSc environment not found at $petsc_dir"
+  set compile_exit_code = 1
+  goto cleanup
+endif
+
+if ($?CONDA_PREFIX != 0) then
+  echo "Using PETSc from $petsc_dir"
+endif
+
 # Add git commit hash and package versions to the source code
 csh -f ./src/UPSY/basic/git_commit_hash_and_package_versions/add_git_commit_hash_and_package_versions_to_code.csh "$compiler_flags"
 if ($status != 0) then
@@ -88,14 +118,14 @@ set in_build_dir = 1
 
 if ($version == 'dev') then
 
-  cmake -G Ninja -DPETSC_DIR=`brew --prefix petsc` \
+  cmake -G Ninja -DPETSC_DIR="$petsc_dir" \
     -DDO_ASSERTIONS=ON \
     -DDO_RESOURCE_TRACKING=ON \
     -DEXTRA_Fortran_FLAGS="$cmake_flags" ..
 
 else if ($version == 'perf') then
 
-  cmake -G Ninja -DPETSC_DIR=`brew --prefix petsc` \
+  cmake -G Ninja -DPETSC_DIR="$petsc_dir" \
     -DDO_ASSERTIONS=OFF \
     -DDO_RESOURCE_TRACKING=OFF \
     -DEXTRA_Fortran_FLAGS="$cmake_flags" ..

--- a/environment-ci.yml
+++ b/environment-ci.yml
@@ -6,6 +6,7 @@ dependencies:
   - python=3.12
   - numpy=2.4.3
   - netcdf4=1.7.4
+  - h5py
 
   # Stuff to compile models
   - openmpi=5.0.10

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - python=3.12
   - numpy=2.4.3
   - netcdf4=1.7.4
+  - h5py
 
   # Stuff to compile models
   - openmpi=5.0.10
@@ -31,7 +32,7 @@ dependencies:
   - pyshp
   - scipy
   - shapely
-  - xarray 
+  - xarray
   - pip
   - setuptools >=61
   - tqdm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "cmocean",
     "dask",
     "geopandas",
+    "h5py",
     "matplotlib",
     "netcdf4",
     "numpy",

--- a/src/LADDIE/main/LADDIE_program.f90
+++ b/src/LADDIE/main/LADDIE_program.f90
@@ -24,7 +24,7 @@ program LADDIE_program
 ! ===== Preamble =====
 ! ====================
 
-  use petscksp
+  use petsc, only: PetscFinalize
   use precisions, only: dp
   use basic_program_info, only: program_name
   use mpi_basic, only: par, initialise_parallelisation
@@ -82,7 +82,6 @@ program LADDIE_program
 
   ! Initialise MPI parallelisation and PETSc
   call initialise_parallelisation
-  call PetscInitialize( PETSC_NULL_CHARACTER, perr)
 
   call print_git_commit_hash_and_package_versions
 
@@ -148,7 +147,6 @@ program LADDIE_program
 
   ! Finalise PETSc and MPI parallelisation
   call PetscFinalize( perr)
-  call MPI_FINALIZE( ierr)
 
 
 end program LADDIE_program

--- a/src/UFEMISM/main/UFEMISM_program.f90
+++ b/src/UFEMISM/main/UFEMISM_program.f90
@@ -11,7 +11,7 @@ program UFEMISM_program
   ! =                                                                             =
   ! ===============================================================================
 
-  use petscksp
+  use petsc, only: PetscFinalize
   use precisions, only: dp
   use basic_program_info, only: program_name
   use mpi_basic, only: par, initialise_parallelisation
@@ -53,7 +53,6 @@ program UFEMISM_program
 
   ! Initialise MPI parallelisation and PETSc
   call initialise_parallelisation
-  call PetscInitialize( PETSC_NULL_CHARACTER, perr)
 
   call print_git_commit_hash_and_package_versions
 
@@ -137,6 +136,5 @@ program UFEMISM_program
 
   ! Finalise PETSc and MPI parallelisation
   call PetscFinalize( perr)
-  call MPI_FINALIZE( ierr)
 
 end program UFEMISM_program

--- a/src/UFEMISM/main/UFEMISM_program.f90
+++ b/src/UFEMISM/main/UFEMISM_program.f90
@@ -30,6 +30,7 @@ program UFEMISM_program
   use component_tests, only: run_all_component_tests
   use checksum_mod, only: create_checksum_logfile
   use git_commit_hash_and_package_versions, only: print_git_commit_hash_and_package_versions
+  use mpi_f08, only: MPI_WTIME, MPI_ALLREDUCE, MPI_IN_PLACE, MPI_DOUBLE_PRECISION, MPI_MAX, MPI_COMM_WORLD
 
   implicit none
 

--- a/src/UFEMISM/main/UFEMISM_unit_test_program.f90
+++ b/src/UFEMISM/main/UFEMISM_unit_test_program.f90
@@ -11,6 +11,7 @@ program UFEMISM_unit_test_program
   use unit_tests, only: run_all_unit_tests
   use crash_mod, only: crash
   use git_commit_hash_and_package_versions, only: print_git_commit_hash_and_package_versions
+  use mpi_f08, only: MPI_WTIME
 
   implicit none
 

--- a/src/UFEMISM/main/UFEMISM_unit_test_program.f90
+++ b/src/UFEMISM/main/UFEMISM_unit_test_program.f90
@@ -1,6 +1,6 @@
 program UFEMISM_unit_test_program
 
-  use petscksp
+  use petsc, only: PetscFinalize
   use precisions, only: dp
   use basic_program_info, only: program_name
   use mpi_basic, only: par, initialise_parallelisation
@@ -22,7 +22,6 @@ program UFEMISM_unit_test_program
 
   ! Initialise MPI parallelisation and PETSc
   call initialise_parallelisation
-  call PetscInitialize( PETSC_NULL_CHARACTER, perr)
 
   call print_git_commit_hash_and_package_versions
 
@@ -59,6 +58,5 @@ program UFEMISM_unit_test_program
 
   ! Finalise PETSc and MPI parallelisation
   call PetscFinalize( perr)
-  call MPI_FINALIZE( ierr)
 
 end program UFEMISM_unit_test_program

--- a/src/UPSY/CMakeLists.txt
+++ b/src/UPSY/CMakeLists.txt
@@ -21,6 +21,7 @@ set( UPSY_program_sources_raw
 	"${CMAKE_CURRENT_SOURCE_DIR}/UPSY_unit_test_program.f90"
 	"${CMAKE_CURRENT_SOURCE_DIR}/UPSY_multinode_unit_test_program.f90"
 	"${CMAKE_CURRENT_SOURCE_DIR}/UPSY_component_test_program_PETSc_matrix_solving.f90"
+	"${CMAKE_CURRENT_SOURCE_DIR}/UPSY_component_test_program_PETSc_DMPLEX.f90"
 	"${CMAKE_CURRENT_SOURCE_DIR}/UPSY_component_test_program_mesh_creation.f90"
 	"${CMAKE_CURRENT_SOURCE_DIR}/UPSY_component_test_program_mesh_focussing.f90"
 	"${CMAKE_CURRENT_SOURCE_DIR}/UPSY_component_test_program_mesh_discretisation.f90"

--- a/src/UPSY/UPSY_component_test_program_PETSc_DMPLEX.f90
+++ b/src/UPSY/UPSY_component_test_program_PETSc_DMPLEX.f90
@@ -3,7 +3,7 @@ program UPSY_component_test_program_PETSc_DMPLEX
   use basic_program_info, only: program_name
   use precisions, only: dp
   use mpi_basic, only: par
-  use petscksp, only: PetscInitialize, PETSC_NULL_CHARACTER, PetscFinalize
+  use petsc, only: PetscFinalize
   use mpi_basic, only: initialise_parallelisation
   use parameters, only: initialise_constants
   use call_stack_and_comp_time_tracking, only: initialise_control_and_resource_tracker, routine_path
@@ -25,7 +25,6 @@ program UPSY_component_test_program_PETSc_DMPLEX
 
   ! Initialise MPI parallelisation and PETSc
   call initialise_parallelisation
-  call PetscInitialize( PETSC_NULL_CHARACTER, perr)
 
   call print_git_commit_hash_and_package_versions
 
@@ -63,6 +62,5 @@ program UPSY_component_test_program_PETSc_DMPLEX
 
   ! Finalise PETSc and MPI parallelisation
   call PetscFinalize( perr)
-  call MPI_FINALIZE( ierr)
 
 end program UPSY_component_test_program_PETSc_DMPLEX

--- a/src/UPSY/UPSY_component_test_program_PETSc_DMPLEX.f90
+++ b/src/UPSY/UPSY_component_test_program_PETSc_DMPLEX.f90
@@ -13,7 +13,7 @@ program UPSY_component_test_program_PETSc_DMPLEX
   use git_commit_hash_and_package_versions, only: print_git_commit_hash_and_package_versions
 
   use ct_basic, only: create_component_tests_output_folder
-  use ct_PETSc_matrix_solving, only: run_all_PETSc_matrix_solving_tests
+  use ct_PETSc_DMPLEX_basics, only: create_simple_DMPLEX
 
   implicit none
 
@@ -52,6 +52,7 @@ program UPSY_component_test_program_PETSc_DMPLEX
   end if
 
   call create_component_tests_output_folder( foldername_output)
+  call create_simple_DMPLEX()
 
   ! Stop the clock
   tstop = MPI_WTIME()

--- a/src/UPSY/UPSY_component_test_program_PETSc_DMPLEX.f90
+++ b/src/UPSY/UPSY_component_test_program_PETSc_DMPLEX.f90
@@ -51,7 +51,7 @@ program UPSY_component_test_program_PETSc_DMPLEX
   end if
 
   call create_component_tests_output_folder( foldername_output)
-  call create_simple_DMPLEX()
+  call create_simple_DMPLEX( foldername_output)
 
   ! Stop the clock
   tstop = MPI_WTIME()

--- a/src/UPSY/UPSY_component_test_program_PETSc_DMPLEX.f90
+++ b/src/UPSY/UPSY_component_test_program_PETSc_DMPLEX.f90
@@ -1,0 +1,67 @@
+program UPSY_component_test_program_PETSc_DMPLEX
+
+  use basic_program_info, only: program_name
+  use precisions, only: dp
+  use mpi_basic, only: par
+  use petscksp, only: PetscInitialize, PETSC_NULL_CHARACTER, PetscFinalize
+  use mpi_basic, only: initialise_parallelisation
+  use parameters, only: initialise_constants
+  use call_stack_and_comp_time_tracking, only: initialise_control_and_resource_tracker, routine_path
+  use basic_model_utilities, only: print_model_start, print_model_end
+  use mpi_f08, only: MPI_WTIME, MPI_FINALIZE
+  use crash_mod, only: crash
+  use git_commit_hash_and_package_versions, only: print_git_commit_hash_and_package_versions
+
+  use ct_basic, only: create_component_tests_output_folder
+  use ct_PETSc_matrix_solving, only: run_all_PETSc_matrix_solving_tests
+
+  implicit none
+
+  integer             :: perr, ierr
+  character(len=1024) :: foldername_output, foldername_test_matrix_equations
+  real(dp)            :: tstart, tstop, tcomp
+
+  program_name = 'UPSY_component_test_program_PETSc_DMPLEX'
+
+  ! Initialise MPI parallelisation and PETSc
+  call initialise_parallelisation
+  call PetscInitialize( PETSC_NULL_CHARACTER, perr)
+
+  call print_git_commit_hash_and_package_versions
+
+  ! Initialise constants (pi, NaN, ...)
+  call initialise_constants
+
+  ! Start the clock
+  tstart = MPI_WTIME()
+
+  ! Print the model start message to the terminal
+  call print_model_start
+
+  ! Initialise the control and resource tracker
+  call initialise_control_and_resource_tracker
+
+  ! Get the input arguments
+  if (iargc() == 2) then
+    call getarg( 1, foldername_output               )  ! path/to/UPSY-models/automated_testing/UPSY/component_test_PETSc_matrix_solving/results
+    call getarg( 2, foldername_test_matrix_equations)  ! path/to/UPSY-models/automated_testing/UPSY/test_matrix_equations
+    if (par%primary) write(0,*) ''
+    if (par%primary) write(0,*) '   Writing component test results to  ' // trim( foldername_output) // '...'
+  else
+    call crash('needs input argument [foldername_output] and [foldername_test_matrix_equations]')
+  end if
+
+  call create_component_tests_output_folder( foldername_output)
+
+  ! Stop the clock
+  tstop = MPI_WTIME()
+  tcomp = tstop - tstart
+
+  ! Print the program end message to the terminal
+  call print_model_end( tcomp)
+
+  ! Finalise PETSc and MPI parallelisation
+  call PetscFinalize( perr)
+  call MPI_FINALIZE( ierr)
+
+end program UPSY_component_test_program_PETSc_DMPLEX

--- a/src/UPSY/UPSY_component_test_program_PETSc_matrix_solving.f90
+++ b/src/UPSY/UPSY_component_test_program_PETSc_matrix_solving.f90
@@ -3,7 +3,7 @@ program UPSY_component_test_program_PETSc_matrix_solving
   use basic_program_info, only: program_name
   use precisions, only: dp
   use mpi_basic, only: par
-  use petscksp, only: PetscInitialize, PETSC_NULL_CHARACTER, PetscFinalize
+  use petsc, only: PetscFinalize
   use mpi_basic, only: initialise_parallelisation
   use parameters, only: initialise_constants
   use call_stack_and_comp_time_tracking, only: initialise_control_and_resource_tracker, routine_path
@@ -25,7 +25,6 @@ program UPSY_component_test_program_PETSc_matrix_solving
 
   ! Initialise MPI parallelisation and PETSc
   call initialise_parallelisation
-  call PetscInitialize( PETSC_NULL_CHARACTER, perr)
 
   call print_git_commit_hash_and_package_versions
 
@@ -63,6 +62,5 @@ program UPSY_component_test_program_PETSc_matrix_solving
 
   ! Finalise PETSc and MPI parallelisation
   call PetscFinalize( perr)
-  call MPI_FINALIZE( ierr)
 
 end program UPSY_component_test_program_PETSc_matrix_solving

--- a/src/UPSY/UPSY_component_test_program_mesh_creation.f90
+++ b/src/UPSY/UPSY_component_test_program_mesh_creation.f90
@@ -3,7 +3,7 @@ program UPSY_component_test_program_mesh_creation
   use basic_program_info, only: program_name
   use precisions, only: dp
   use mpi_basic, only: par
-  use petscksp, only: PetscInitialize, PETSC_NULL_CHARACTER, PetscFinalize
+  use petsc, only: PetscFinalize
   use mpi_basic, only: initialise_parallelisation
   use parameters, only: initialise_constants
   use call_stack_and_comp_time_tracking, only: initialise_control_and_resource_tracker, routine_path
@@ -25,7 +25,6 @@ program UPSY_component_test_program_mesh_creation
 
   ! Initialise MPI parallelisation and PETSc
   call initialise_parallelisation
-  call PetscInitialize( PETSC_NULL_CHARACTER, perr)
 
   call print_git_commit_hash_and_package_versions
 
@@ -62,6 +61,5 @@ program UPSY_component_test_program_mesh_creation
 
   ! Finalise PETSc and MPI parallelisation
   call PetscFinalize( perr)
-  call MPI_FINALIZE( ierr)
 
 end program UPSY_component_test_program_mesh_creation

--- a/src/UPSY/UPSY_component_test_program_mesh_discretisation.f90
+++ b/src/UPSY/UPSY_component_test_program_mesh_discretisation.f90
@@ -3,7 +3,7 @@ program UPSY_component_test_program_mesh_discretisation
   use basic_program_info, only: program_name
   use precisions, only: dp
   use mpi_basic, only: par
-  use petscksp, only: PetscInitialize, PETSC_NULL_CHARACTER, PetscFinalize
+  use petsc, only: PetscFinalize
   use mpi_basic, only: initialise_parallelisation
   use parameters, only: initialise_constants
   use call_stack_and_comp_time_tracking, only: initialise_control_and_resource_tracker, routine_path
@@ -28,7 +28,6 @@ program UPSY_component_test_program_mesh_discretisation
 
   ! Initialise MPI parallelisation and PETSc
   call initialise_parallelisation
-  call PetscInitialize( PETSC_NULL_CHARACTER, perr)
 
   call print_git_commit_hash_and_package_versions
 
@@ -68,6 +67,5 @@ program UPSY_component_test_program_mesh_discretisation
 
   ! Finalise PETSc and MPI parallelisation
   call PetscFinalize( perr)
-  call MPI_FINALIZE( ierr)
 
 end program UPSY_component_test_program_mesh_discretisation

--- a/src/UPSY/UPSY_component_test_program_mesh_focussing.f90
+++ b/src/UPSY/UPSY_component_test_program_mesh_focussing.f90
@@ -3,7 +3,7 @@ program UPSY_component_test_program_mesh_focussing
   use basic_program_info, only: program_name
   use precisions, only: dp
   use mpi_basic, only: par
-  use petscksp, only: PetscInitialize, PETSC_NULL_CHARACTER, PetscFinalize
+  use petsc, only: PetscFinalize
   use mpi_basic, only: initialise_parallelisation
   use parameters, only: initialise_constants
   use call_stack_and_comp_time_tracking, only: initialise_control_and_resource_tracker, routine_path
@@ -28,7 +28,6 @@ program UPSY_component_test_program_mesh_focussing
 
   ! Initialise MPI parallelisation and PETSc
   call initialise_parallelisation
-  call PetscInitialize( PETSC_NULL_CHARACTER, perr)
 
   call print_git_commit_hash_and_package_versions
 
@@ -68,6 +67,5 @@ program UPSY_component_test_program_mesh_focussing
 
   ! Finalise PETSc and MPI parallelisation
   call PetscFinalize( perr)
-  call MPI_FINALIZE( ierr)
 
 end program UPSY_component_test_program_mesh_focussing

--- a/src/UPSY/UPSY_component_test_program_mesh_remapping_grid_grid.f90
+++ b/src/UPSY/UPSY_component_test_program_mesh_remapping_grid_grid.f90
@@ -3,7 +3,7 @@ program UPSY_component_test_program_mesh_remapping_grid_grid
   use basic_program_info, only: program_name
   use precisions, only: dp
   use mpi_basic, only: par
-  use petscksp, only: PetscInitialize, PETSC_NULL_CHARACTER, PetscFinalize
+  use petsc, only: PetscFinalize
   use mpi_basic, only: initialise_parallelisation
   use parameters, only: initialise_constants
   use call_stack_and_comp_time_tracking, only: initialise_control_and_resource_tracker, routine_path
@@ -28,7 +28,6 @@ program UPSY_component_test_program_mesh_remapping_grid_grid
 
   ! Initialise MPI parallelisation and PETSc
   call initialise_parallelisation
-  call PetscInitialize( PETSC_NULL_CHARACTER, perr)
 
   call print_git_commit_hash_and_package_versions
 
@@ -68,6 +67,5 @@ program UPSY_component_test_program_mesh_remapping_grid_grid
 
   ! Finalise PETSc and MPI parallelisation
   call PetscFinalize( perr)
-  call MPI_FINALIZE( ierr)
 
 end program UPSY_component_test_program_mesh_remapping_grid_grid

--- a/src/UPSY/UPSY_component_test_program_mesh_remapping_mesh_grid.f90
+++ b/src/UPSY/UPSY_component_test_program_mesh_remapping_mesh_grid.f90
@@ -3,7 +3,7 @@ program UPSY_component_test_program_mesh_remapping_mesh_grid
   use basic_program_info, only: program_name
   use precisions, only: dp
   use mpi_basic, only: par
-  use petscksp, only: PetscInitialize, PETSC_NULL_CHARACTER, PetscFinalize
+  use petsc, only: PetscFinalize
   use mpi_basic, only: initialise_parallelisation
   use parameters, only: initialise_constants
   use call_stack_and_comp_time_tracking, only: initialise_control_and_resource_tracker, routine_path
@@ -29,7 +29,6 @@ program UPSY_component_test_program_mesh_remapping_mesh_grid
 
   ! Initialise MPI parallelisation and PETSc
   call initialise_parallelisation
-  call PetscInitialize( PETSC_NULL_CHARACTER, perr)
 
   call print_git_commit_hash_and_package_versions
 
@@ -70,6 +69,5 @@ program UPSY_component_test_program_mesh_remapping_mesh_grid
 
   ! Finalise PETSc and MPI parallelisation
   call PetscFinalize( perr)
-  call MPI_FINALIZE( ierr)
 
 end program UPSY_component_test_program_mesh_remapping_mesh_grid

--- a/src/UPSY/UPSY_component_test_program_mesh_remapping_mesh_mesh.f90
+++ b/src/UPSY/UPSY_component_test_program_mesh_remapping_mesh_mesh.f90
@@ -3,7 +3,7 @@ program UPSY_component_test_program_mesh_remapping_mesh_mesh
   use basic_program_info, only: program_name
   use precisions, only: dp
   use mpi_basic, only: par
-  use petscksp, only: PetscInitialize, PETSC_NULL_CHARACTER, PetscFinalize
+  use petsc, only: PetscFinalize
   use mpi_basic, only: initialise_parallelisation
   use parameters, only: initialise_constants
   use call_stack_and_comp_time_tracking, only: initialise_control_and_resource_tracker, routine_path
@@ -28,7 +28,6 @@ program UPSY_component_test_program_mesh_remapping_mesh_mesh
 
   ! Initialise MPI parallelisation and PETSc
   call initialise_parallelisation
-  call PetscInitialize( PETSC_NULL_CHARACTER, perr)
 
   call print_git_commit_hash_and_package_versions
 
@@ -68,6 +67,5 @@ program UPSY_component_test_program_mesh_remapping_mesh_mesh
 
   ! Finalise PETSc and MPI parallelisation
   call PetscFinalize( perr)
-  call MPI_FINALIZE( ierr)
 
 end program UPSY_component_test_program_mesh_remapping_mesh_mesh

--- a/src/UPSY/UPSY_multinode_unit_test_program.f90
+++ b/src/UPSY/UPSY_multinode_unit_test_program.f90
@@ -6,7 +6,7 @@ program UPSY_multinode_unit_test_program
   use mpi_basic, only: par
   use crash_mod, only: crash
   use model_configuration, only: C
-  use petscksp, only: PetscInitialize, PETSC_NULL_CHARACTER, PetscFinalize
+  use petsc, only: PetscFinalize
   use mpi_basic, only: initialise_parallelisation_multinode_tests
   use parameters, only: initialise_constants
   use call_stack_and_comp_time_tracking, only: initialise_control_and_resource_tracker, crash
@@ -32,7 +32,6 @@ program UPSY_multinode_unit_test_program
 
   ! Initialise MPI parallelisation and PETSc
   call initialise_parallelisation_multinode_tests
-  call PetscInitialize( PETSC_NULL_CHARACTER, perr)
 
   call print_git_commit_hash_and_package_versions
 
@@ -78,6 +77,5 @@ program UPSY_multinode_unit_test_program
 
   ! Finalise PETSc and MPI parallelisation
   call PetscFinalize( perr)
-  call MPI_FINALIZE( ierr)
 
 end program UPSY_multinode_unit_test_program

--- a/src/UPSY/UPSY_unit_test_program.f90
+++ b/src/UPSY/UPSY_unit_test_program.f90
@@ -6,7 +6,7 @@ program UPSY_unit_test_program
   use mpi_basic, only: par
   use crash_mod, only: crash
   use model_configuration, only: C
-  use petscksp, only: PetscInitialize, PETSC_NULL_CHARACTER, PetscFinalize
+  use petsc, only: PetscFinalize
   use mpi_basic, only: initialise_parallelisation
   use parameters, only: initialise_constants
   use call_stack_and_comp_time_tracking, only: initialise_control_and_resource_tracker
@@ -35,7 +35,6 @@ program UPSY_unit_test_program
 
   ! Initialise MPI parallelisation and PETSc
   call initialise_parallelisation
-  call PetscInitialize( PETSC_NULL_CHARACTER, perr)
 
   call print_git_commit_hash_and_package_versions
 
@@ -84,6 +83,5 @@ program UPSY_unit_test_program
 
   ! Finalise PETSc and MPI parallelisation
   call PetscFinalize( perr)
-  call MPI_FINALIZE( ierr)
 
 end program UPSY_unit_test_program

--- a/src/UPSY/basic/mpi_parallelisation/mpi_basic.f90
+++ b/src/UPSY/basic/mpi_parallelisation/mpi_basic.f90
@@ -41,7 +41,6 @@ contains
     integer :: ierr, i, n, perr
 
     ! Use MPI to create copies of the program on all the processors, so the model can run in parallel.
-    ! call MPI_INIT( ierr)
     call PetscInitialize( PETSC_NULL_CHARACTER, perr)
 
     ! Get global number and rank of processes
@@ -87,7 +86,7 @@ contains
     integer :: ierr, i, n
 
     ! Use MPI to create copies of the program on all the processors, so the model can run in parallel.
-    call MPI_INIT( ierr)
+    call PetscInitialize( PETSC_NULL_CHARACTER, perr)
 
     ! Get global number and rank of processes
     call MPI_COMM_SIZE( MPI_COMM_WORLD, par%n, ierr)

--- a/src/UPSY/basic/mpi_parallelisation/mpi_basic.f90
+++ b/src/UPSY/basic/mpi_parallelisation/mpi_basic.f90
@@ -83,7 +83,7 @@ contains
     ! the hybrid distributed/shared memory code.
 
     ! Local variables:
-    integer :: ierr, i, n
+    integer :: perr, ierr, i, n
 
     ! Use MPI to create copies of the program on all the processors, so the model can run in parallel.
     call PetscInitialize( PETSC_NULL_CHARACTER, perr)

--- a/src/UPSY/basic/mpi_parallelisation/mpi_basic.f90
+++ b/src/UPSY/basic/mpi_parallelisation/mpi_basic.f90
@@ -6,6 +6,7 @@ module mpi_basic
     MPI_COMM_SPLIT_TYPE, MPI_COMM_TYPE_SHARED, MPI_BARRIER, MPI_INFO_NULL, MPI_COMM_SPLIT, &
     MPI_ALLREDUCE, MPI_IN_PLACE, MPI_INTEGER, MPI_SUM, MPI_SEND, MPI_RECV, MPI_STATUS, &
     MPI_ANY_TAG
+  use petscksp, only: PetscInitialize, PETSC_NULL_CHARACTER
 
   implicit none
 
@@ -37,10 +38,11 @@ contains
   subroutine initialise_parallelisation
 
     ! Local variables:
-    integer :: ierr, i, n
+    integer :: ierr, i, n, perr
 
     ! Use MPI to create copies of the program on all the processors, so the model can run in parallel.
-    call MPI_INIT( ierr)
+    ! call MPI_INIT( ierr)
+    call PetscInitialize( PETSC_NULL_CHARACTER, perr)
 
     ! Get global number and rank of processes
     call MPI_COMM_SIZE( MPI_COMM_WORLD, par%n, ierr)

--- a/src/UPSY/validation/component_tests/PETSc_finite_elements/ct_PETSc_DMPLEX_basics.f90
+++ b/src/UPSY/validation/component_tests/PETSc_finite_elements/ct_PETSc_DMPLEX_basics.f90
@@ -1,14 +1,19 @@
 module ct_PETSc_DMPLEX_basics
 
-#include <petsc/finclude/petscdm.h>
-#include <petsc/finclude/petscdmplex.h>
-
   use precisions, only: dp
-  use mpi, only: MPI_COMM_WORLD         ! The newer mpi_f08 uses a wrapper type for communicators, which PETSc doesn't support...
-  use petscdmplex, only: tDM, DMPlexCreate, DMPlexSetChart, DMPlexSetConeSize, &
-    DMSetUp, DMPlexSetCone, DMPlexSymmetrize, DMPlexStratify, DMDestroy, &
-    tVec, DMSetCoordinates
-  use petsc_basic, only: vec_double2petsc
+  use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine
+  use crash_mod, only: warning
+  use petsc, only: tDM, tVec, tPetscViewer, tPetscSection, DMPlexCreate, DMSetDimension, &
+    DMSetCoordinateDim, DMPlexSetChart, DMPlexSetConeSize, DMSetUp, DMPlexSetCone, &
+    DMPlexSymmetrize, DMPlexStratify, DMGetCoordinateSection, DMGetCoordinateDM, &
+    DMCreateLocalVector, DMSetCoordinatesLocal, PetscSectionSetChart, PetscSectionSetDof, &
+    PetscSectionSetUp, VecSetValues, VecAssemblyBegin, VecAssemblyEnd, INSERT_VALUES, &
+    VecDestroy, DMPlexTopologyView, &
+    DMPlexCoordinatesView, PetscViewerCreate, PetscViewerSetType, &
+    PETSCVIEWERASCII, PETSCVIEWERHDF5, PetscViewerFileSetMode, FILE_MODE_WRITE, &
+    PetscViewerFileSetName, PetscViewerPushFormat, PetscViewerPopFormat, &
+    PETSC_VIEWER_ASCII_INFO_DETAIL, DMView, PetscViewerDestroy, PETSC_COMM_WORLD, &
+    DMDestroy, PetscObjectSetName, PETSC_VIEWER_HDF5_PETSC
 
   implicit none
 
@@ -18,7 +23,7 @@ module ct_PETSc_DMPLEX_basics
 
 contains
 
-  subroutine create_simple_DMPLEX
+  subroutine create_simple_DMPLEX( foldername_output)
     ! Implements the example from https://petsc.org/release/manual/dmplex/#ch-unstructured
     !
     ! The dummy mesh looks like this:
@@ -41,17 +46,32 @@ contains
     !                  \   |   /
     !                   [v1;p3]
 
+    ! In/output variables:
+    character(len=*), intent(in) :: foldername_output
+
+    ! Local variables:
+    character(len=*), parameter         :: routine_name = 'create_simple_DMPLEX'
     type(tDM)                           :: dm
     integer                             :: perr
-    real(dp), dimension(0:5 ,2)         :: vertex_coords
-    real(dp), dimension(0:10,2)         :: coords_nby2
+    real(dp), dimension(0:3,2)          :: vertex_coords
+    real(dp), dimension(0:3,2)          :: coords_nby2
     real(dp), dimension(:), allocatable :: coords_2n
     integer                             :: n,i
     real(dp)                            :: x,y
     type(tVec)                          :: coords
+    type(tDM)                           :: coordinate_dm
+    type(tPetscSection)                 :: coordinate_section
+    integer, dimension(0:7)             :: coords_indices
+    character(len=:), allocatable       :: filename
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
 
     ! Create a DMPlex object
-    call DMPlexCreate( MPI_COMM_WORLD, dm, perr)
+    call DMPlexCreate( PETSC_COMM_WORLD, dm, perr)
+    call PetscObjectSetName( dm, 'demo_dmplex', perr)
+    call DMSetDimension( dm, 2, perr)
+    call DMSetCoordinateDim( dm, 2, perr)
 
     ! The example mesh has 11 'points' (vertices, faces, and edges)
     call DMPlexSetChart( dm, 0, 11, perr)
@@ -93,50 +113,90 @@ contains
     vertex_coords( 2,:) = [ 0._dp,  1._dp]
     vertex_coords( 3,:) = [ 1._dp,  0._dp]
 
-    ! DMPLEX point coordinates
-
-    ! Point 0 = face 0, spanned by vertices [0,1,2]
-    coords_nby2(  0,:) = (vertex_coords( 0,:) + vertex_coords( 1,:) + vertex_coords( 2,:)) / 3._dp
-    ! Point 1 = face 1, spanned by vertices [0,1,2]
-    coords_nby2(  1,:) = (vertex_coords( 1,:) + vertex_coords( 2,:) + vertex_coords( 3,:)) / 3._dp
-    ! Point 2 = vertex 0
-    coords_nby2(  2,:) = vertex_coords( 0,:)
-    ! Point 3 = vertex 1
-    coords_nby2(  3,:) = vertex_coords( 1,:)
-    ! Point 4 = vertex 2
-    coords_nby2(  4,:) = vertex_coords( 2,:)
-    ! Point 5 = vertex 3
-    coords_nby2(  5,:) = vertex_coords( 3,:)
-    ! Point 6 = edge 0, spanned by vertices [0,1]
-    coords_nby2(  6,:) = (vertex_coords( 0,:) + vertex_coords( 1,:)) / 2._dp
-    ! Point 7 = edge 1, spanned by vertices [1,2]
-    coords_nby2(  7,:) = (vertex_coords( 1,:) + vertex_coords( 2,:)) / 2._dp
-    ! Point 8 = edge 2, spanned by vertices [0,2]
-    coords_nby2(  8,:) = (vertex_coords( 0,:) + vertex_coords( 2,:)) / 2._dp
-    ! Point 9 = edge 3, spanned by vertices [2,3]
-    coords_nby2(  9,:) = (vertex_coords( 2,:) + vertex_coords( 3,:)) / 2._dp
-    ! Point 10 = edge 4, spanned by vertices [1,3]
-    coords_nby2( 10,:) = (vertex_coords( 1,:) + vertex_coords( 3,:)) / 2._dp
+    ! DMPLEX coordinates are stored only for the vertices of the mesh.
+    ! The topology points for faces and edges do not have coordinate entries.
+    coords_nby2( 0,:) = vertex_coords( 0,:)
+    coords_nby2( 1,:) = vertex_coords( 1,:)
+    coords_nby2( 2,:) = vertex_coords( 2,:)
+    coords_nby2( 3,:) = vertex_coords( 3,:)
 
     ! Reshape from n-by-2 to 2n
-    n = 22
+    n = 8
     allocate( coords_2n( 0:n-1))
-    do i = 0, 10
+    do i = 0, 3
       x = coords_nby2( i,1)
       y = coords_nby2( i,2)
       coords_2n( 2*i  ) = x
       coords_2n( 2*i+1) = y
     end do
 
-    ! Convert to PETSc vector
-    call vec_double2petsc( coords_2n, coords)
+    ! Define two coordinate degrees of freedom for each vertex. The coordinate
+    ! vector must use this DMPlex-owned layout rather than a general parallel Vec.
+    call DMGetCoordinateSection( dm, coordinate_section, perr)
+    call PetscSectionSetChart( coordinate_section, 0, 11, perr)
+    do i = 2, 5
+      call PetscSectionSetDof( coordinate_section, i, 2, perr)
+    end do
+    call PetscSectionSetUp( coordinate_section, perr)
 
-    ! Set DMPLEX point coordinates from the PETSc vector
-    call DMSetCoordinates( dm, coords, perr)
+    ! Create and fill the coordinate DM's local vector.
+    call DMGetCoordinateDM( dm, coordinate_dm, perr)
+    call DMCreateLocalVector( coordinate_dm, coords, perr)
+    do i = 0, 7
+      coords_indices( i) = i
+    end do
+    call VecSetValues( coords, n, coords_indices, coords_2n, INSERT_VALUES, perr)
+    call VecAssemblyBegin( coords, perr)
+    call VecAssemblyEnd( coords, perr)
+    call DMSetCoordinatesLocal( dm, coords, perr)
+    call VecDestroy( coords, perr)
+
+    filename = trim( foldername_output) // '/PETSc_DMPLEX_output.h5'
+    call write_dmplex_to_hdf5( dm, filename)
 
     ! Clean up after yourself
     call DMDestroy( dm, perr)
 
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
   end subroutine create_simple_DMPLEX
+
+  subroutine write_dmplex_to_hdf5( dm, filename)
+
+    ! In/output variables:
+    type(tDM),        intent(in) :: dm
+    character(len=*), intent(in) :: filename
+
+    ! Local variables:
+    character(len=*), parameter :: routine_name = 'write_dmplex_to_hdf5'
+    type(tPetscViewer)          :: viewer
+    integer                     :: perr
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Export DMPLEX to an HDF5 file with the actual topology and coordinate arrays,
+    ! not just the high-level metadata summary.
+
+    ! Open the HDF5 file
+    call PetscViewerCreate( PETSC_COMM_WORLD, viewer, perr)
+    call PetscViewerSetType( viewer, PETSCVIEWERHDF5, perr)
+    call PetscViewerFileSetMode( viewer, FILE_MODE_WRITE, perr)
+    call PetscViewerFileSetName( viewer, trim( filename), perr)
+
+    ! This format is important for saving a DMPlex
+    call PetscViewerPushFormat( viewer, PETSC_VIEWER_HDF5_PETSC, perr)
+
+    ! Write topology + coordinates + labels
+    call DMView( dm, viewer, perr)
+
+    call PetscViewerPopFormat( viewer, perr)
+    call PetscViewerDestroy( viewer, perr)
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine write_dmplex_to_hdf5
 
 end module ct_PETSc_DMPLEX_basics

--- a/src/UPSY/validation/component_tests/PETSc_finite_elements/ct_PETSc_DMPLEX_basics.f90
+++ b/src/UPSY/validation/component_tests/PETSc_finite_elements/ct_PETSc_DMPLEX_basics.f90
@@ -1,0 +1,142 @@
+module ct_PETSc_DMPLEX_basics
+
+#include <petsc/finclude/petscdm.h>
+#include <petsc/finclude/petscdmplex.h>
+
+  use precisions, only: dp
+  use mpi, only: MPI_COMM_WORLD         ! The newer mpi_f08 uses a wrapper type for communicators, which PETSc doesn't support...
+  use petscdmplex, only: tDM, DMPlexCreate, DMPlexSetChart, DMPlexSetConeSize, &
+    DMSetUp, DMPlexSetCone, DMPlexSymmetrize, DMPlexStratify, DMDestroy, &
+    tVec, DMSetCoordinates
+  use petsc_basic, only: vec_double2petsc
+
+  implicit none
+
+  private
+
+  public :: create_simple_DMPLEX
+
+contains
+
+  subroutine create_simple_DMPLEX
+    ! Implements the example from https://petsc.org/release/manual/dmplex/#ch-unstructured
+    !
+    ! The dummy mesh looks like this:
+    !
+    !                   [v2;p4]
+    !                  /   |   \
+    !                /     |     \
+    !              /       |       \
+    !         [e2;p8]      |      [e3;p9]
+    !          /           |           \
+    !        /             |             \
+    !      /               |               \
+    ! [v0;p2]  [f0;p0]  [e1;p7]  [f1;p1]  [v3;p5]
+    !      \               |               /
+    !        \             |             /
+    !          \           |           /
+    !         [e0;p6]      |      [e4;p10]
+    !              \       |       /
+    !                \     |     /
+    !                  \   |   /
+    !                   [v1;p3]
+
+    type(tDM)                           :: dm
+    integer                             :: perr
+    real(dp), dimension(0:5 ,2)         :: vertex_coords
+    real(dp), dimension(0:10,2)         :: coords_nby2
+    real(dp), dimension(:), allocatable :: coords_2n
+    integer                             :: n,i
+    real(dp)                            :: x,y
+    type(tVec)                          :: coords
+
+    ! Create a DMPlex object
+    call DMPlexCreate( MPI_COMM_WORLD, dm, perr)
+
+    ! The example mesh has 11 'points' (vertices, faces, and edges)
+    call DMPlexSetChart( dm, 0, 11, perr)
+
+    ! In 2 dimensions the convention is to first number faces, then vertices, and then edges.
+    ! PETSc indexes from zero
+    !    DMPlexSetConeSize( dm, point, number of points that cover the point)
+    call DMPlexSetConeSize( dm, 0, 3, perr)  ! Points 0 and 1 are faces, each connected to 3 edges.
+    call DMPlexSetConeSize( dm, 1, 3, perr)
+    call DMPlexSetConeSize( dm, 6, 2, perr)  ! Points 6-10 are edges, each connected to 2 vertices.
+    call DMPlexSetConeSize( dm, 7, 2, perr)
+    call DMPlexSetConeSize( dm, 8, 2, perr)
+    call DMPlexSetConeSize( dm, 9, 2, perr)
+    call DMPlexSetConeSize( dm, 10, 2, perr)
+    call DMSetUp( dm, perr)
+
+    !    DMPlexSetCone( dm, point, [points that cover the point])
+    call DMPlexSetCone( dm,  0, [6, 7,  8], perr) ! Point  0 (= face 0) is connected to points [6,7, 8] (= edges [0,1,2])
+    call DMPlexSetCone( dm,  1, [7, 9, 10], perr) ! Point  1 (= face 1) is connected to points [7,9,10] (= edges [1,3,4])  ...so not necessarily counter-clockwise
+    call DMPlexSetCone( dm,  6, [2, 3    ], perr) ! Point  6 (= edge 0) is connected to points [2,3] (= vertices [0,1])
+    call DMPlexSetCone( dm,  7, [3, 4    ], perr) ! Point  7 (= edge 1) is connected to points [3,4] (= vertices [1,2])
+    call DMPlexSetCone( dm,  8, [4, 2    ], perr) ! Point  8 (= edge 2) is connected to points [4,2] (= vertices [2,0])
+    call DMPlexSetCone( dm,  9, [4, 5    ], perr) ! Point  9 (= edge 3) is connected to points [4,5] (= vertices [2,3])
+    call DMPlexSetCone( dm, 10, [5, 3    ], perr) ! Point 10 (= edge 4) is connected to points [5,3] (= vertices [3,1])
+
+    ! Let PETSc automatically figure out the 'supports', i.e. the backward connections (so each
+    ! vertex knows which edges and faces it spans)
+    call DMPlexSymmetrize( dm, perr)
+
+    ! In order to support efficient queries, we construct fast search structures
+    ! and indices for the different types of points
+    call DMPlexStratify( dm, perr)
+
+    ! ADDITION: set coordinates
+
+    ! Basic vertex coordinates
+    vertex_coords( 0,:) = [-1._dp,  0._dp]
+    vertex_coords( 1,:) = [ 0._dp, -1._dp]
+    vertex_coords( 2,:) = [ 0._dp,  1._dp]
+    vertex_coords( 3,:) = [ 1._dp,  0._dp]
+
+    ! DMPLEX point coordinates
+
+    ! Point 0 = face 0, spanned by vertices [0,1,2]
+    coords_nby2(  0,:) = (vertex_coords( 0,:) + vertex_coords( 1,:) + vertex_coords( 2,:)) / 3._dp
+    ! Point 1 = face 1, spanned by vertices [0,1,2]
+    coords_nby2(  1,:) = (vertex_coords( 1,:) + vertex_coords( 2,:) + vertex_coords( 3,:)) / 3._dp
+    ! Point 2 = vertex 0
+    coords_nby2(  2,:) = vertex_coords( 0,:)
+    ! Point 3 = vertex 1
+    coords_nby2(  3,:) = vertex_coords( 1,:)
+    ! Point 4 = vertex 2
+    coords_nby2(  4,:) = vertex_coords( 2,:)
+    ! Point 5 = vertex 3
+    coords_nby2(  5,:) = vertex_coords( 3,:)
+    ! Point 6 = edge 0, spanned by vertices [0,1]
+    coords_nby2(  6,:) = (vertex_coords( 0,:) + vertex_coords( 1,:)) / 2._dp
+    ! Point 7 = edge 1, spanned by vertices [1,2]
+    coords_nby2(  7,:) = (vertex_coords( 1,:) + vertex_coords( 2,:)) / 2._dp
+    ! Point 8 = edge 2, spanned by vertices [0,2]
+    coords_nby2(  8,:) = (vertex_coords( 0,:) + vertex_coords( 2,:)) / 2._dp
+    ! Point 9 = edge 3, spanned by vertices [2,3]
+    coords_nby2(  9,:) = (vertex_coords( 2,:) + vertex_coords( 3,:)) / 2._dp
+    ! Point 10 = edge 4, spanned by vertices [1,3]
+    coords_nby2( 10,:) = (vertex_coords( 1,:) + vertex_coords( 3,:)) / 2._dp
+
+    ! Reshape from n-by-2 to 2n
+    n = 22
+    allocate( coords_2n( 0:n-1))
+    do i = 0, 10
+      x = coords_nby2( i,1)
+      y = coords_nby2( i,2)
+      coords_2n( 2*i  ) = x
+      coords_2n( 2*i+1) = y
+    end do
+
+    ! Convert to PETSc vector
+    call vec_double2petsc( coords_2n, coords)
+
+    ! Set DMPLEX point coordinates from the PETSc vector
+    call DMSetCoordinates( dm, coords, perr)
+
+    ! Clean up after yourself
+    call DMDestroy( dm, perr)
+
+  end subroutine create_simple_DMPLEX
+
+end module ct_PETSc_DMPLEX_basics

--- a/src/UPSY/validation/component_tests/PETSc_matrix_solving/ct_PETSc_matrix_solving.f90
+++ b/src/UPSY/validation/component_tests/PETSc_matrix_solving/ct_PETSc_matrix_solving.f90
@@ -29,8 +29,8 @@ contains
 
     ! Local variables:
     character(len=*), parameter                    :: routine_name = 'run_all_PETSc_matrix_solving_tests'
-    character(len=1024), dimension(10)             :: PETSc_KSPtypes
-    character(len=1024), dimension(6)              :: PETSc_PCtypes
+    character(len=1024), dimension(7)              :: PETSc_KSPtypes
+    character(len=1024), dimension(5)              :: PETSc_PCtypes
     character(len=1024), dimension(:), allocatable :: list_of_test_matrix_names
     character(len=:), allocatable                  :: filename_output
     integer                                        :: i
@@ -40,22 +40,18 @@ contains
     call init_routine( routine_name)
 
     PETSc_KSPtypes(  1) = 'gmres'
-    PETSc_KSPtypes(  2) = 'pipegmres'
-    PETSc_KSPtypes(  3) = 'cg'
-    PETSc_KSPtypes(  4) = 'pipecg'
+    PETSc_KSPtypes(  2) = 'lgmres'
+    PETSc_KSPtypes(  3) = 'fgmres'
+    PETSc_KSPtypes(  4) = 'pipegmres'
     PETSc_KSPtypes(  5) = 'bicg'
     PETSc_KSPtypes(  6) = 'bicgstab'
     PETSc_KSPtypes(  7) = 'ibicgstab'
-    PETSc_KSPtypes(  8) = 'minres'
-    PETSc_KSPtypes(  9) = 'cr'
-    PETSc_KSPtypes( 10) = 'pipecr'
 
     PETSc_PCtypes( 1) = 'bjacobi'
     PETSc_PCtypes( 2) = 'asm'
-    PETSc_PCtypes( 3) = 'gamg'
-    PETSc_PCtypes( 4) = 'gasm'
-    PETSc_PCtypes( 5) = 'jacobi'
-    PETSc_PCtypes( 6) = 'none'
+    PETSc_PCtypes( 3) = 'gasm'
+    PETSc_PCtypes( 4) = 'gamg'
+    PETSc_PCtypes( 5) = 'none'
 
     call list_test_matrix_equations( foldername_test_matrix_equations, list_of_test_matrix_names)
 


### PR DESCRIPTION
Add a little UPSY component test to play around with PETSc's dmplex (unstructured grid) code. It creates a very simple 2-triangle mesh based on the example from the PETSc wiki, writes that mesh to an HDF5 file (similar to NetCDF but less user-friendly, so ofc it's what PETSc uses...), and calls a Python script to visualise the grid from the file.